### PR TITLE
Reduce memory usage when downloading snapshot.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ tonic = "0.7.2"
 prost = "0.10.1"
 prost-types = "0.10.1"
 anyhow = "1"
-reqwest = { version = "0.11.11", optional = true }
+reqwest = { version = "0.11.11", optional = true, features = ["stream"] }
+futures-util = { version = "0.3.21", optional = true }
 
 [build-dependencies]
 tonic-build = { version = "0.7.2", features = ["prost"] }
@@ -27,4 +28,4 @@ tokio = "1.20.1"
 
 [features]
 default = ["download_snapshots"]
-download_snapshots = ["reqwest"]
+download_snapshots = ["reqwest", "futures-util"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -295,9 +295,12 @@ impl QdrantClient {
         snapshot_name: Option<T>,
         rest_api_uri: Option<T>,
     ) -> Result<()>
-        where
-            T: ToString + Clone,
+    where
+        T: ToString + Clone,
     {
+        use futures_util::StreamExt;
+        use std::io::Write;
+
         let snapshot_name = match snapshot_name {
             Some(sn) => sn.to_string(),
             _ => match self
@@ -314,7 +317,7 @@ impl QdrantClient {
             },
         };
 
-        let file = reqwest::get(format!(
+        let mut stream = reqwest::get(format!(
             "{}/collections/{}/snapshots/{}",
             rest_api_uri
                 .map(|uri| uri.to_string())
@@ -322,11 +325,19 @@ impl QdrantClient {
             collection_name.to_string(),
             snapshot_name
         ))
-            .await?
-            .bytes()
-            .await?;
+        .await?
+        .bytes_stream();
 
-        let _ = std::fs::write(out_path.into(), file);
+        let out_path = out_path.into();
+        let _ = std::fs::remove_file(&out_path);
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(out_path)?;
+
+        while let Some(chunk) = stream.next().await {
+            file.write(&chunk?)?;
+        }
 
         Ok(())
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
 pub use crate::client::*;
 pub use crate::qdrant::{
-    point_id, CreateCollection, DeleteCollection, Distance, PointStruct, SearchPoints,
+    point_id, CreateCollection, DeleteCollection, Distance, PointStruct, SearchPoints, Value,
 };


### PR DESCRIPTION
Add `Value` to the prelude, and stream the snapshot download to the file to reduce memory usage.