### PR TITLE
Extract example to binary, improve instructions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ futures-util = { version = "0.3.25", optional = true }
 tonic-build = { version = "0.8.4", features = ["prost"] }
 
 [dev-dependencies]
-tokio = "1.24.2"
+tokio = { version = "1.24.2", features = ["rt-multi-thread"] }
 
 [features]
 default = ["download_snapshots"]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ More info about gRPC in [documentation](https://qdrant.tech/documentation/quick_
 
 ### Making requests
 
+Add necessary dependencies:
+
+```bash
+cargo add qdrant-client anyhow tonic tokio --features tokio/rt-multi-thread
+```
+
+Add search example from [`examples/search.rs`](./examples/search.rs) to your `src/main.rs`:
+
 ```rust
 use anyhow::Result;
 use qdrant_client::prelude::*;
@@ -58,7 +66,15 @@ async fn main() -> Result<()> {
     let client = QdrantClient::new(Some(config)).await?;
 
     let collections_list = client.list_collections().await?;
-    // ListCollectionsResponse { collections: [CollectionDescription { name: "test" }], time: 3.27e-6 }
+    dbg!(collections_list);
+    // collections_list = ListCollectionsResponse {
+    //     collections: [
+    //         CollectionDescription {
+    //             name: "test",
+    //         },
+    //     ],
+    //     time: 1.78e-6,
+    // }
 
     let collection_name = "test";
     client.delete_collection(collection_name).await?;
@@ -77,6 +93,7 @@ async fn main() -> Result<()> {
         .await?;
 
     let collection_info = client.collection_info(collection_name).await?;
+    dbg!(collection_info);
 
     let payload: Payload = vec![("foo", "Bar".into()), ("bar", 12.into())]
         .into_iter()
@@ -102,23 +119,34 @@ async fn main() -> Result<()> {
             ..Default::default()
         })
         .await?;
+    dbg!(search_result);
     // search_result = SearchResponse {
     //     result: [
     //         ScoredPoint {
-    //         id: Some(
-    //             PointId {
-    //                 point_id_options: Some(Num(0)),
-    //             },
-    //         ),
-    //         payload: {},
-    //         score: 1.0000001,
-    //         vector: [],
-    //         version: 0,
-    //     },
+    //             id: Some(
+    //                 PointId {
+    //                     point_id_options: Some(
+    //                         Num(
+    //                             0,
+    //                         ),
+    //                     ),
+    //                 },
+    //             ),
+    //             payload: {},
+    //             score: 1.0000001,
+    //             version: 0,
+    //             vectors: None,
+    //         },
     //     ],
     //     time: 5.312e-5,
     // }
 
     Ok(())
 }
+```
+
+Or run the example from this project directly:
+
+```bash
+cargo run --example search
 ```

--- a/examples/search.rs
+++ b/examples/search.rs
@@ -1,0 +1,91 @@
+use anyhow::Result;
+use qdrant_client::prelude::*;
+use qdrant_client::qdrant::vectors_config::Config;
+use qdrant_client::qdrant::{CreateCollection, SearchPoints, VectorParams, VectorsConfig};
+use std::collections::HashMap;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Example of top level client
+    // You may also use tonic-generated client from `src/qdrant.rs`
+    let config = QdrantClientConfig::from_url("http://localhost:6334");
+    let client = QdrantClient::new(Some(config)).await?;
+
+    let collections_list = client.list_collections().await?;
+    dbg!(collections_list);
+    // collections_list = ListCollectionsResponse {
+    //     collections: [
+    //         CollectionDescription {
+    //             name: "test",
+    //         },
+    //     ],
+    //     time: 1.78e-6,
+    // }
+
+    let collection_name = "test";
+    client.delete_collection(collection_name).await?;
+
+    client
+        .create_collection(&CreateCollection {
+            collection_name: collection_name.into(),
+            vectors_config: Some(VectorsConfig {
+                config: Some(Config::Params(VectorParams {
+                    size: 10,
+                    distance: Distance::Cosine.into(),
+                })),
+            }),
+            ..Default::default()
+        })
+        .await?;
+
+    let collection_info = client.collection_info(collection_name).await?;
+    dbg!(collection_info);
+
+    let payload: Payload = vec![("foo", "Bar".into()), ("bar", 12.into())]
+        .into_iter()
+        .collect::<HashMap<_, Value>>()
+        .into();
+
+    let points = vec![PointStruct::new(0, vec![12.; 10], payload)];
+    client
+        .upsert_points_blocking(collection_name, points, None)
+        .await?;
+
+    let search_result = client
+        .search_points(&SearchPoints {
+            collection_name: collection_name.into(),
+            vector: vec![11.; 10],
+            filter: None,
+            limit: 10,
+            with_vectors: None,
+            with_payload: None,
+            params: None,
+            score_threshold: None,
+            offset: None,
+            ..Default::default()
+        })
+        .await?;
+    dbg!(search_result);
+    // search_result = SearchResponse {
+    //     result: [
+    //         ScoredPoint {
+    //             id: Some(
+    //                 PointId {
+    //                     point_id_options: Some(
+    //                         Num(
+    //                             0,
+    //                         ),
+    //                     ),
+    //                 },
+    //             ),
+    //             payload: {},
+    //             score: 1.0000001,
+    //             version: 0,
+    //             vectors: None,
+    //         },
+    //     ],
+    //     time: 5.312e-5,
+    // }
+
+    Ok(())
+}


### PR DESCRIPTION
Depends on https://github.com/qdrant/rust-client/pull/22

This extracts the README example to a binary example. This helps to catch compilation errors early as dependency APIs change.

This also improves the instructions for running the example, by defining the necessary `cargo add` command with dependencies.