### PR TITLE
switch from openssl to rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "1"
 # If you don't want to have serde as a dependency, please consider contributing a feature flag
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.11.17", optional = true, features = ["stream"] }
+reqwest = { version = "0.11.17", optional = true, default-features = false, features = ["stream", "rustls-tls"] }
 futures-util = { version = "0.3.28", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
On the client side, it's far easier than on the server to do so, and I had problems building for lambda using the default openssl.

This applies if the `download_snapshots` feature is active (which it is by default).