### PR TITLE
Add serde feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ prost-types = "0.11.9"
 anyhow = "1"
 
 # If you don't want to have serde as a dependency, please consider contributing a feature flag
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
 reqwest = { version = "0.11.18", optional = true, default-features = false, features = ["stream", "rustls-tls"] }
 futures-util = { version = "0.3.28", optional = true }
 
@@ -29,5 +29,6 @@ tonic-build = { version = "0.9.2", features = ["prost"] }
 tokio = { version = "1.28.1", features = ["rt-multi-thread"] }
 
 [features]
-default = ["download_snapshots"]
+default = ["download_snapshots", "serde"]
 download_snapshots = ["reqwest", "futures-util"]
+serde = ["dep:serde", "dep:serde_json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,7 @@ tokio = { version = "1.28.1", features = ["rt-multi-thread"] }
 default = ["download_snapshots", "serde"]
 download_snapshots = ["reqwest", "futures-util"]
 serde = ["dep:serde", "dep:serde_json"]
+
+[[example]]
+name = "search"
+required-features = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ prost = "0.11.9"
 prost-types = "0.11.9"
 anyhow = "1"
 
-# If you don't want to have serde as a dependency, please consider contributing a feature flag
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 reqwest = { version = "0.11.18", optional = true, default-features = false, features = ["stream", "rustls-tls"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,6 +28,7 @@ use crate::qdrant::{
     VectorsSelector, WithPayloadSelector, WithVectorsSelector, WriteOrdering,
 };
 use anyhow::{bail, Result};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::future::Future;
@@ -1205,7 +1206,8 @@ impl From<u64> for PointId {
     }
 }
 
-#[derive(Clone, PartialEq, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Payload(HashMap<String, Value>);
 
 impl From<Payload> for HashMap<String, Value> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod prelude;
 #[allow(clippy::all)]
 #[rustfmt::skip]
 pub mod qdrant;
+#[cfg(feature = "serde")]
 pub mod serde;
 
 #[cfg(test)]


### PR DESCRIPTION
Adds a `serde` feature flag which enables the `serde` and `serde_json` dependencies and implementations (feature is enabled by default). 
