### PR TITLE
Fix compiler warnings without `download_snapshots` feature

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -27,10 +27,11 @@ use crate::qdrant::{
     SetPayloadPoints, Struct, UpdateCollection, UpsertPoints, Value, Vector, Vectors,
     VectorsSelector, WithPayloadSelector, WithVectorsSelector, WriteOrdering,
 };
-use anyhow::{bail, Result};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::future::Future;
+#[cfg(feature = "download_snapshots")]
 use std::path::PathBuf;
 use std::time::Duration;
 use tonic::codegen::InterceptedService;
@@ -1146,7 +1147,7 @@ impl QdrantClient {
                 .first()
             {
                 Some(sn) => sn.name.clone(),
-                _ => bail!(
+                _ => anyhow::bail!(
                     "No snapshots found for collection {}",
                     collection_name.to_string()
                 ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,7 @@ mod tests {
             .await?;
 
         client.create_snapshot(collection_name).await?;
+        #[cfg(feature = "download_snapshots")]
         client
             .download_snapshot("test.tar", collection_name, None, None)
             .await?;


### PR DESCRIPTION
When the `download_snapshots` isn't used, some compiler warnings were shown. This PR fixes that.

For example:

```rust
$ cargo check --no-default-features
warning: unused import: `bail`
  --> src/client.rs:30:14
   |
30 | use anyhow::{bail, Result};
   |              ^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `std::path::PathBuf`
  --> src/client.rs:35:5
   |
35 | use std::path::PathBuf;
   |     ^^^^^^^^^^^^^^^^^^

warning: `qdrant-client` (lib) generated 2 warnings (run `cargo fix --lib -p qdrant-client` to apply 2 suggestions)
    Finished dev [unoptimized + debuginfo] target(s) in 7.50s
```