### PR TITLE
batch large upserts, improve client connect API

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,7 @@ use serde_json::json;
 async fn main() -> Result<()> {
     // Example of top level client
     // You may also use tonic-generated client from `src/qdrant.rs`
-    let config = QdrantClientConfig::from_url("http://localhost:6334");
-    let client = QdrantClient::new(Some(config))?;
+    let client = QdrantClient::from_url("http://localhost:6334").build()?;
 
     let collections_list = client.list_collections().await?;
     dbg!(collections_list);
@@ -197,14 +196,10 @@ The client needs to be configured properly to access the service.
 
 ```rust
 async fn make_client() -> Result<QdrantClient> {
-    let mut config = QdrantClientConfig::from_url("http://xxxxxxxxxx.eu-central.aws.cloud.qdrant.io:6334");
-    // using an env variable for the API KEY for example
-    let api_key = std::env::var("QDRANT_API_KEY").ok();
-
-    if let Some(api_key) = api_key {
-        config.set_api_key(&api_key);
-    }
-    let client = QdrantClient::new(Some(config)).await?;
+    let client = QdrantClient::from_url("http://xxxxxxxxxx.eu-central.aws.cloud.qdrant.io:6334")
+        // using an env variable for the API KEY for example
+        .with_api_key(std::env::var("QDRANT_API_KEY"))
+        .build()?;
     Ok(client)
 }
 ```

--- a/src/client.rs
+++ b/src/client.rs
@@ -675,7 +675,9 @@ impl QdrantClient {
                                 wait: Some(block),
                                 points: chunk.to_vec(),
                                 ordering: ordering_ref.cloned(),
-                            }).await?.into_inner();
+                            })
+                            .await?
+                            .into_inner();
                         resp.result = result;
                         resp.time += time;
                     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -721,7 +721,7 @@ impl QdrantClient {
         ordering: Option<WriteOrdering>,
         chunk_size: usize,
     ) -> Result<PointsOperationResponse> {
-        self._upsert_points_batch(collection_name, &points, false, ordering, chunk_size)
+        self._upsert_points_batch(collection_name, &points, true, ordering, chunk_size)
             .await
     }
 


### PR DESCRIPTION
As discussed this morning, I added functionality to the client to split `upsert_point` calls with too many `points`. I randomly chose the split limit at 1024 points.

I also couldn't help myself and improved the client-connecting API to be more builder-like. See the README.md changes for the improvement. I can roll back this change if you think it's too much, but I personally don't think we'll have too high a maintainance cost for the nicer interface.