### PR TITLE
introduce basic ops on `Range` and `ValuesCount`

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -94,12 +94,17 @@ macro_rules! impl_common {
 
             /// Normalizes the representation of a given range
             /// by removing redundant constraints.
+            /// 
+            /// Redundant constraints occur when both `gt` and `gte`,
+            /// or both `lt` and `lte` fields are specified. In this case,
+            /// at least one of them will never be satisfied, so it can safely
+            /// be removed, leaving the stricter constraint.
             ///
             /// This is mostly useful for debugging purposes. At the moment,
             /// filters do not require that they are passed collapsed ranges.
             ///
-            /// You don't need to call this function if you constructed
-            /// your range using the `range!` macro or by calling other library functions,
+            /// You don't need to call this function if you construct
+            /// ranges by calling the library functions,
             /// as they never produce ranges with redundant constraints.
             pub fn collapse(&mut self) {
                 *self = Self::from_bounds(self.start_bound(), self.end_bound())

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -94,7 +94,7 @@ macro_rules! impl_common {
 
             /// Normalizes the representation of a given range
             /// by removing redundant constraints.
-            /// 
+            ///
             /// Redundant constraints occur when both `gt` and `gte`,
             /// or both `lt` and `lte` fields are specified. In this case,
             /// at least one of them will never be satisfied, so it can safely
@@ -627,6 +627,8 @@ impl std::ops::Not for MatchValue {
 
 #[cfg(test)]
 mod tests {
+    use super::Range;
+    use super::ValuesCount;
     use crate::qdrant::{Condition, Filter, NestedCondition};
 
     #[test]
@@ -663,14 +665,9 @@ mod tests {
             Filter::any([Condition::has_id([0])]),
         )]);
     }
-}
-
-#[cfg(test)]
-mod range_tests {
-    use super::Range;
 
     #[test]
-    fn test_empty() {
+    fn test_range_empty() {
         assert!(Range::empty().is_empty());
         assert!(Range::from(0.0..0.0).excluding_lower().is_empty());
         assert!(Range::from(1.0..0.0).excluding_lower().is_empty());
@@ -678,7 +675,7 @@ mod range_tests {
     }
 
     #[test]
-    fn test_empty_edge_cases() {
+    fn test_range_empty_edge_cases() {
         assert!(Range::from(f64::NAN..).is_empty());
         assert!(Range::only(f64::NAN).is_empty());
         assert!(Range::from(..f64::NEG_INFINITY).is_empty());
@@ -690,14 +687,14 @@ mod range_tests {
     }
 
     #[test]
-    fn test_contains() {
+    fn test_range_contains() {
         assert!(Range::any().contains(0.0));
         assert!(Range::only(0.0).contains(0.0));
         assert!(!Range::only(0.0).contains(1.0));
     }
 
     #[test]
-    fn test_contains_edge_cases() {
+    fn test_range_contains_edge_cases() {
         assert!(Range::from(..=f64::INFINITY).contains(f64::INFINITY));
         assert!(Range::from(f64::INFINITY..).contains(f64::INFINITY));
 
@@ -722,7 +719,7 @@ mod range_tests {
     }
 
     #[test]
-    fn test_intersect() {
+    fn test_range_intersection() {
         assert_eq!(
             Range::from(0.0..1.0)
                 .excluding_lower()
@@ -756,7 +753,7 @@ mod range_tests {
     }
 
     #[test]
-    fn test_collapse() {
+    fn test_range_collapse() {
         {
             let mut range = Range {
                 gt: Some(0.0),
@@ -788,14 +785,9 @@ mod range_tests {
             assert_eq!(range, Range::from(0.0..=1.0).excluding_lower());
         }
     }
-}
-
-#[cfg(test)]
-mod values_count_tests {
-    use super::ValuesCount;
 
     #[test]
-    fn test_empty() {
+    fn test_values_count_empty() {
         assert!(ValuesCount::empty().is_empty());
 
         assert!(ValuesCount::from(0..0).excluding_lower().is_empty());
@@ -808,7 +800,7 @@ mod values_count_tests {
     }
 
     #[test]
-    fn test_contains() {
+    fn test_values_count_contains() {
         assert!(ValuesCount::any().contains(0));
         assert!(ValuesCount::only(0).contains(0));
 
@@ -822,7 +814,7 @@ mod values_count_tests {
     }
 
     #[test]
-    fn test_intersection() {
+    fn test_values_count_intersection() {
         assert_eq!(
             ValuesCount::from(0..1)
                 .excluding_lower()

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -216,6 +216,11 @@ impl Range {
         self.intersect(other);
         self
     }
+
+    /// Returns `true` if `val` is contained in the range.
+    pub fn contains(&self, val: f64) -> bool {
+        <Self as RangeBounds<f64>>::contains(self, &val)
+    }
 }
 
 impl RangeBounds<f64> for Range {
@@ -438,6 +443,11 @@ impl ValuesCount {
     pub fn intersection(mut self, other: &Self) -> Self {
         self.intersect(other);
         self
+    }
+
+    /// Returns `true` if `val` is contained in the range.
+    pub fn contains(&self, val: u64) -> bool {
+        <Self as RangeBounds<u64>>::contains(self, &val)
     }
 }
 
@@ -857,7 +867,6 @@ mod tests {
 #[cfg(test)]
 mod range_tests {
     use super::Range;
-    use std::ops::RangeBounds;
 
     #[test]
     fn test_empty() {
@@ -874,44 +883,44 @@ mod range_tests {
         {
             let range = Range::only(f64::NAN);
             assert!(range.is_empty());
-            assert!(test_vals.iter().all(|val| !range.contains(val)));
+            assert!(test_vals.iter().all(|&val| !range.contains(val)));
         }
 
         {
             let range = range!((f64::NAN)..);
             assert!(range.is_empty());
-            assert!(test_vals.iter().all(|val| !range.contains(val)));
+            assert!(test_vals.iter().all(|&val| !range.contains(val)));
         }
 
         {
             let range = range!((f64::INFINITY)..);
             assert!(range.is_empty());
-            assert!(test_vals.iter().all(|val| !range.contains(val)));
+            assert!(test_vals.iter().all(|&val| !range.contains(val)));
         }
 
         {
             let range = range!(..(f64::NEG_INFINITY));
             assert!(range.is_empty());
-            assert!(test_vals.iter().all(|val| !range.contains(val)));
+            assert!(test_vals.iter().all(|&val| !range.contains(val)));
         }
     }
 
     #[test]
     fn test_contains() {
-        assert!(Range::any().contains(&0.0));
+        assert!(Range::any().contains(0.0));
     }
 
     #[test]
     fn test_contains_edge_cases() {
         {
             let range = range!(..(f64::INFINITY));
-            assert!(range.contains(&0.0));
+            assert!(range.contains(0.0));
             assert!(!range.is_empty());
         }
 
         {
             let range = range!((f64::INFINITY)=..);
-            assert!(range.contains(&f64::INFINITY));
+            assert!(range.contains(f64::INFINITY));
             assert!(!range.is_empty());
         }
     }
@@ -981,7 +990,6 @@ mod range_tests {
 #[cfg(test)]
 mod values_count_tests {
     use super::ValuesCount;
-    use std::ops::RangeBounds;
 
     #[test]
     fn test_empty() {
@@ -998,16 +1006,16 @@ mod values_count_tests {
 
     #[test]
     fn test_contains() {
-        assert!(ValuesCount::any().contains(&0));
-        assert!(ValuesCount::only(0).contains(&0));
+        assert!(ValuesCount::any().contains(0));
+        assert!(ValuesCount::only(0).contains(0));
 
-        assert!(values_count!(0..=1).contains(&1));
-        assert!(values_count!(0=..=1).contains(&0));
+        assert!(values_count!(0..=1).contains(1));
+        assert!(values_count!(0=..=1).contains(0));
 
-        assert!(!values_count!(0..0).contains(&0));
-        assert!(!values_count!(1..0).contains(&0));
-        assert!(!values_count!(0..1).contains(&0));
-        assert!(!values_count!(0..1).contains(&1));
+        assert!(!values_count!(0..0).contains(0));
+        assert!(!values_count!(1..0).contains(0));
+        assert!(!values_count!(0..1).contains(0));
+        assert!(!values_count!(0..1).contains(1));
     }
 
     #[test]


### PR DESCRIPTION
This introduces some typical operations on `Range` and `ValueCount`, conforms them to `std::ops::RangeBounds` and provides macros to construct them with a syntax analogous to normal Rust ranges.

I'm a bit unsure about the macros for a number of reasons:
1. they require a different syntax to make it possible to exclude the lower bound,
2. they sometimes don't parse very well, requiring parentheses around some expressions like `f64::INFINITY`,
3. `rustfmt` rewrites `a=..=b` into `a = ..=b`,

but, on the other hand, they drastically reduce the verbosity of the other ways to construct these types.

An alternative approach would be to allow construction as `From<std::ops::Range>` etc. and allow to exclude the lower bound by a separate method:

```rust
Range::from(0..=1).exclude_lower()
```

The various checks for infinites and NaNs on `f64` are perhaps somewhat excessive, as these can't be expressed in JSON and thus stored in payloads, but these still can be passed into `Range` if the latter isn't constructed carefully and produce surprising query results.