### PR TITLE
Add missing dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ More info about gRPC in [documentation](https://qdrant.tech/documentation/quick_
 Add necessary dependencies:
 
 ```bash
-cargo add qdrant-client anyhow tonic tokio --features tokio/rt-multi-thread
+cargo add qdrant-client anyhow tonic tokio serde-json --features tokio/rt-multi-thread
 ```
 
 Add search example from [`examples/search.rs`](./examples/search.rs) to your `src/main.rs`:


### PR DESCRIPTION
In the README example we use `serde-json`, but it was missing from the `cargo add` command.

It shows a formatting/linter error. It is not related to this PR. I have fixed it in the v1.5.0 update PR which will come after this, so I suggest to ignore it for now and merge this.