### PR TITLE
Implementing dedicated function for full text search filtering

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -349,7 +349,11 @@ impl From<i64> for MatchValue {
 
 impl From<String> for MatchValue {
     fn from(value: String) -> Self {
-        Self::Keyword(value)
+        if value.contains(char::is_whitespace) {
+            Self::Text(value)
+        } else {
+            Self::Keyword(value)
+        }
     }
 }
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -186,6 +186,24 @@ impl qdrant::Condition {
         }
     }
 
+    /// create a Condition to initiate full text match
+    ///
+    /// # Examples:
+    /// ```
+    /// qdrant_client::qdrant::Condition::matches_text("description", "good cheap");
+    /// ```
+    pub fn matches_text(field: impl Into<String>, query: impl Into<String>) -> Self {
+        Self {
+            condition_one_of: Some(ConditionOneOf::Field(qdrant::FieldCondition {
+                key: field.into(),
+                r#match: Some(qdrant::Match {
+                    match_value: Some(MatchValue::Text(query.into())),
+                }),
+                ..Default::default()
+            })),
+        }
+    }
+
     /// create a Condition that checks numeric fields against a range
     ///
     /// # Examples:
@@ -331,11 +349,7 @@ impl From<i64> for MatchValue {
 
 impl From<String> for MatchValue {
     fn from(value: String) -> Self {
-        if value.contains(char::is_whitespace) {
-            Self::Text(value)
-        } else {
-            Self::Keyword(value)
-        }
+        Self::Keyword(value)
     }
 }
 


### PR DESCRIPTION
This PR addresses #85 which denotes that in order to use the full text search filter, a hacky workaround of inserting whitespace is required. This PR implements a dedicated function (`matches_text`) for initiating a full text-search, reflecting the python client's api.
Existing implementations of the full text search will continue to work as before.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
