### PR TITLE
Add crates.io metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ homepage = "https://qdrant.tech/"
 license = "Apache-2.0"
 repository = "https://github.com/qdrant/rust-client"
 readme = "README.md"
+categories = ["database", "api-bindings"]
+keywords = ["qdrant", "vector-search", "search-engine", "client", "grpc"]
 
 [dependencies]
 tonic = { version = "0.9.2", features = ["tls", "tls-roots"] }


### PR DESCRIPTION
This PR adds missing metadata for the crates repositories.

Those tags are indexed and help people find what they need on `crates.io` and `lib.rs`

The possible categories can be found here https://crates.io/category_slugs

The keywords are free form.

e.g. https://crates.io/keywords/qdrant