### PR TITLE
refactor: Enhance URL handling in QdrantClientConfig

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+### All Submissions:
+
+* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
+* [ ] Have you followed the guidelines in our Contributing document?
+* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
+
+<!-- You can erase any parts of this template not applicable to your Pull Request. -->
+
+### New Feature Submissions:
+
+1. [ ] Does your submission pass tests?
+2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
+3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?
+
+### Changes to Core Features:
+
+* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
+* [ ] Have you written new tests for your core changes, as applicable?
+* [ ] Have you successfully ran tests with your changes locally?

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Cargo.lock
 
 .idea
 test.tar
+*.iml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant-client"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 authors = ["Qdrant Team <team@qdrant.com>"]
 description = "Rust client for Qdrant Vector Search Engine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant-client"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 authors = ["Qdrant Team <team@qdrant.com>"]
 description = "Rust client for Qdrant Vector Search Engine"
@@ -9,8 +9,6 @@ homepage = "https://qdrant.tech/"
 license = "Apache-2.0"
 repository = "https://github.com/qdrant/rust-client"
 readme = "README.md"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 tonic = { version = "0.9.2", features = ["tls", "tls-roots"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 reqwest = { version = "0.11.24", optional = true, default-features = false, features = ["stream", "rustls-tls"] }
 futures-util = { version = "0.3.30", optional = true }
+url = "2.5.0"
 
 [dev-dependencies]
 tonic-build = { version = "0.9.2", features = ["prost"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 reqwest = { version = "0.11.22", optional = true, default-features = false, features = ["stream", "rustls-tls"] }
-futures-util = { version = "0.3.28", optional = true }
+futures-util = { version = "0.3.29", optional = true }
 
 [dev-dependencies]
 tonic-build = { version = "0.9.2", features = ["prost"] }
-tokio = { version = "1.32.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.34.0", features = ["rt-multi-thread"] }
 
 [features]
 default = ["download_snapshots", "serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant-client"
-version = "1.8.0"
+version = "1.6.0"
 edition = "2021"
 authors = ["Qdrant Team <team@qdrant.com>"]
 description = "Rust client for Qdrant Vector Search Engine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ anyhow = "1"
 
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
-reqwest = { version = "0.11.22", optional = true, default-features = false, features = ["stream", "rustls-tls"] }
-futures-util = { version = "0.3.29", optional = true }
+reqwest = { version = "0.11.24", optional = true, default-features = false, features = ["stream", "rustls-tls"] }
+futures-util = { version = "0.3.30", optional = true }
 
 [dev-dependencies]
 tonic-build = { version = "0.9.2", features = ["prost"] }
-tokio = { version = "1.34.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.36.0", features = ["rt-multi-thread"] }
 
 [features]
 default = ["download_snapshots", "serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant-client"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 authors = ["Qdrant Team <team@qdrant.com>"]
 description = "Rust client for Qdrant Vector Search Engine"
@@ -18,12 +18,12 @@ anyhow = "1"
 
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
-reqwest = { version = "0.11.18", optional = true, default-features = false, features = ["stream", "rustls-tls"] }
+reqwest = { version = "0.11.22", optional = true, default-features = false, features = ["stream", "rustls-tls"] }
 futures-util = { version = "0.3.28", optional = true }
 
 [dev-dependencies]
 tonic-build = { version = "0.9.2", features = ["prost"] }
-tokio = { version = "1.29.1", features = ["rt-multi-thread"] }
+tokio = { version = "1.32.0", features = ["rt-multi-thread"] }
 
 [features]
 default = ["download_snapshots", "serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant-client"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 authors = ["Qdrant Team <team@qdrant.com>"]
 description = "Rust client for Qdrant Vector Search Engine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant-client"
-version = "1.6.0"
+version = "1.8.0"
 edition = "2021"
 authors = ["Qdrant Team <team@qdrant.com>"]
 description = "Rust client for Qdrant Vector Search Engine"

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ async fn main() -> Result<()> {
 
     let points = vec![PointStruct::new(0, vec![12.; 10], payload)];
     client
-        .upsert_points_blocking(collection_name, points, None)
+        .upsert_points_blocking(collection_name, None, points, None)
         .await?;
 
     let search_result = client

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ More info about gRPC in [documentation](https://qdrant.tech/documentation/quick_
 Add necessary dependencies:
 
 ```bash
-cargo add qdrant-client anyhow tonic tokio --features tokio/rt-multi-thread
+cargo add qdrant-client anyhow tonic tokio serde-json --features tokio/rt-multi-thread
 ```
 
 Add search example from [`examples/search.rs`](./examples/search.rs) to your `src/main.rs`:

--- a/examples/search.rs
+++ b/examples/search.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
 
     let points = vec![PointStruct::new(0, vec![12.; 10], payload)];
     client
-        .upsert_points_blocking(collection_name, points, None)
+        .upsert_points_blocking(collection_name, None, points, None)
         .await?;
 
     let search_result = client

--- a/proto/collections.proto
+++ b/proto/collections.proto
@@ -358,14 +358,14 @@ message PayloadSchemaInfo {
 message CollectionInfo {
   CollectionStatus status = 1; // operating condition of the collection
   OptimizerStatus optimizer_status = 2; // status of collection optimizers
-  uint64 vectors_count = 3; // number of vectors in the collection
+  optional uint64 vectors_count = 3; // Approximate number of vectors in the collection
   uint64 segments_count = 4; // Number of independent segments
   reserved 5; // Deprecated
   reserved 6; // Deprecated
   CollectionConfig config = 7; // Configuration
   map<string, PayloadSchemaInfo> payload_schema = 8; // Collection data types
-  uint64 points_count = 9; // number of points in the collection
-  optional uint64 indexed_vectors_count = 10; // number of indexed vectors in the collection.
+  optional uint64 points_count = 9; // Approximate number of points in the collection
+  optional uint64 indexed_vectors_count = 10; // Approximate number of indexed vectors in the collection.
 }
 
 message ChangeAliases {

--- a/proto/collections.proto
+++ b/proto/collections.proto
@@ -208,10 +208,15 @@ message ProductQuantization {
   optional bool always_ram = 2; // If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
 }
 
+message BinaryQuantization {
+  optional bool always_ram = 1; // If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
+}
+
 message QuantizationConfig {
   oneof quantization {
     ScalarQuantization scalar = 1;
     ProductQuantization product = 2;
+    BinaryQuantization binary = 3;
   }
 }
 
@@ -224,6 +229,7 @@ message QuantizationConfigDiff {
     ScalarQuantization scalar = 1;
     ProductQuantization product = 2;
     Disabled disabled = 3;
+    BinaryQuantization binary = 4;
   }
 }
 

--- a/proto/collections.proto
+++ b/proto/collections.proto
@@ -278,12 +278,14 @@ message CollectionParams {
   optional VectorsConfig vectors_config = 5; // Configuration for vectors
   optional uint32 replication_factor = 6; // Number of replicas of each shard that network tries to maintain
   optional uint32 write_consistency_factor = 7; // How many replicas should apply the operation for us to consider it successful
+  optional uint32 read_fan_out_factor = 8; // Fan-out every read request to these many additional remote nodes (and return first available response)
 }
 
 message CollectionParamsDiff {
   optional uint32 replication_factor = 1; // Number of replicas of each shard that network tries to maintain
   optional uint32 write_consistency_factor = 2; // How many replicas should apply the operation for us to consider it successful
   optional bool on_disk_payload = 3; // If true - point's payload will not be stored in memory
+  optional uint32 read_fan_out_factor = 4; // Fan-out every read request to these many additional remote nodes (and return first available response)
 }
 
 message CollectionConfig {

--- a/proto/collections.proto
+++ b/proto/collections.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 message VectorParams {
   uint64 size = 1; // Size of the vectors
@@ -37,6 +38,14 @@ message VectorsConfigDiff {
   }
 }
 
+message SparseVectorParams {
+  optional SparseIndexConfig index = 1; // Configuration of sparse index
+}
+
+message SparseVectorConfig {
+  map<string, SparseVectorParams> map = 1;
+}
+
 message GetCollectionInfoRequest {
   string collection_name = 1; // Name of the collection
 }
@@ -63,6 +72,7 @@ enum Distance {
   Cosine = 1;
   Euclid = 2;
   Dot = 3;
+  Manhattan = 4;
 }
 
 enum CollectionStatus {
@@ -128,6 +138,18 @@ message HnswConfigDiff {
    Number of additional payload-aware links per node in the index graph. If not set - regular M parameter will be used.
    */
   optional uint64 payload_m = 6;
+}
+
+message SparseIndexConfig {
+  /*
+    Prefer a full scan search upto (excluding) this number of vectors.
+    Note: this is number of vectors, not KiloBytes.
+   */
+  optional uint64 full_scan_threshold = 1;
+  /*
+  Store inverted index on disk. If set to false, the index will be stored in RAM.
+   */
+  optional bool on_disk = 2;
 }
 
 message WalConfigDiff {
@@ -233,6 +255,11 @@ message QuantizationConfigDiff {
   }
 }
 
+enum ShardingMethod {
+  Auto = 0; // Auto-sharding based on record ids
+  Custom = 1; // Shard by user-defined key
+}
+
 message CreateCollection {
   string collection_name = 1; // Name of the collection
   reserved 2; // Deprecated
@@ -248,6 +275,8 @@ message CreateCollection {
   optional uint32 write_consistency_factor = 12; // How many replicas should apply the operation for us to consider it successful, default = 1
   optional string init_from_collection = 13; // Specify name of the other collection to copy data from
   optional QuantizationConfig quantization_config = 14; // Quantization configuration of vector
+  optional ShardingMethod sharding_method = 15; // Sharding method
+  optional SparseVectorConfig sparse_vectors_config = 16; // Configuration for sparse vectors
 }
 
 message UpdateCollection {
@@ -258,6 +287,7 @@ message UpdateCollection {
   optional HnswConfigDiff hnsw_config = 5; // New HNSW parameters for the collection index
   optional VectorsConfigDiff vectors_config = 6; // New vector parameters
   optional QuantizationConfigDiff quantization_config = 7; // Quantization configuration of vector
+  optional SparseVectorConfig sparse_vectors_config = 8; // New sparse vector parameters
 }
 
 message DeleteCollection {
@@ -279,6 +309,8 @@ message CollectionParams {
   optional uint32 replication_factor = 6; // Number of replicas of each shard that network tries to maintain
   optional uint32 write_consistency_factor = 7; // How many replicas should apply the operation for us to consider it successful
   optional uint32 read_fan_out_factor = 8; // Fan-out every read request to these many additional remote nodes (and return first available response)
+  optional ShardingMethod sharding_method = 9; // Sharding method
+  optional SparseVectorConfig sparse_vectors_config = 10; // Configuration for sparse vectors
 }
 
 message CollectionParamsDiff {
@@ -390,18 +422,28 @@ enum ReplicaState {
   Partial = 2; // The shard is partially loaded and is currently receiving data from other shards
   Initializing = 3; // Collection is being created
   Listener = 4; // A shard which receives data, but is not used for search; Useful for backup shards
+  PartialSnapshot = 5; // Snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard
+}
+
+message ShardKey {
+  oneof key {
+    string keyword = 1; // String key
+    uint64 number = 2; // Number key
+  }
 }
 
 message LocalShardInfo {
   uint32 shard_id = 1; // Local shard id
   uint64 points_count = 2; // Number of points in the shard
   ReplicaState state = 3;  // Is replica active
+  optional ShardKey shard_key = 4; // User-defined shard key
 }
 
 message RemoteShardInfo {
   uint32 shard_id = 1; // Local shard id
   uint64 peer_id = 2; // Remote peer id
   ReplicaState state = 3; // Is replica active
+  optional ShardKey shard_key = 4; // User-defined shard key
 }
 
 message ShardTransferInfo {
@@ -423,11 +465,28 @@ message MoveShard {
   uint32 shard_id = 1; // Local shard id
   uint64 from_peer_id = 2;
   uint64 to_peer_id = 3;
+  optional ShardTransferMethod method = 4;
+}
+
+enum ShardTransferMethod {
+  StreamRecords = 0;
+  Snapshot = 1;
 }
 
 message Replica {
   uint32 shard_id = 1;
   uint64 peer_id = 2;
+}
+
+message CreateShardKey {
+    ShardKey shard_key = 1; // User-defined shard key
+    optional uint32 shards_number = 2; // Number of shards to create per shard key
+    optional uint32 replication_factor = 3; // Number of replicas of each shard to create
+    repeated uint64 placement = 4; // List of peer ids, allowed to create shards. If empty - all peers are allowed
+}
+
+message DeleteShardKey {
+    ShardKey shard_key = 1; // Shard key to delete
 }
 
 message UpdateCollectionClusterSetupRequest {
@@ -437,10 +496,32 @@ message UpdateCollectionClusterSetupRequest {
     MoveShard replicate_shard = 3;
     MoveShard abort_transfer = 4;
     Replica drop_replica = 5;
+    CreateShardKey create_shard_key = 7;
+    DeleteShardKey delete_shard_key = 8;
   }
   optional uint64 timeout = 6; // Wait timeout for operation commit in seconds, if not specified - default value will be supplied
 }
 
 message UpdateCollectionClusterSetupResponse {
   bool result = 1;
+}
+
+message CreateShardKeyRequest {
+    string collection_name = 1; // Name of the collection
+    CreateShardKey request = 2; // Request to create shard key
+    optional uint64 timeout = 3; // Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+}
+
+message DeleteShardKeyRequest {
+    string collection_name = 1; // Name of the collection
+    DeleteShardKey request = 2; // Request to delete shard key
+    optional uint64 timeout = 3; // Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+}
+
+message CreateShardKeyResponse {
+    bool result = 1;
+}
+
+message DeleteShardKeyResponse {
+    bool result = 1;
 }

--- a/proto/collections.proto
+++ b/proto/collections.proto
@@ -50,6 +50,19 @@ message GetCollectionInfoRequest {
   string collection_name = 1; // Name of the collection
 }
 
+message CollectionExistsRequest {
+  string collection_name = 1;
+}
+
+message CollectionExists {
+  bool exists = 1;
+}
+
+message CollectionExistsResponse {
+  CollectionExists result = 1;
+  double time = 2; // Time spent to process
+}
+
 message ListCollectionsRequest {
 }
 
@@ -90,6 +103,7 @@ enum PayloadSchemaType {
   Geo = 4;
   Text = 5;
   Bool = 6;
+  Datetime = 7;
 }
 
 enum QuantizationType {
@@ -113,7 +127,7 @@ message OptimizerStatus {
 message HnswConfigDiff {
   /*
   Number of edges per node in the index graph. Larger the value - more accurate the search, more space required.
-   */
+  */
   optional uint64 m = 1;
   /*
   Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build the index.
@@ -127,16 +141,19 @@ message HnswConfigDiff {
   */
   optional uint64 full_scan_threshold = 3;
   /*
-  Number of parallel threads used for background index building. If 0 - auto selection.
-   */
+  Number of parallel threads used for background index building.
+  If 0 - automatically select from 8 to 16.
+  Best to keep between 8 and 16 to prevent likelihood of building broken/inefficient HNSW graphs.
+  On small CPUs, less threads are used.
+  */
   optional uint64 max_indexing_threads = 4;
   /*
   Store HNSW index on disk. If set to false, the index will be stored in RAM.
-   */
+  */
   optional bool on_disk = 5;
   /*
-   Number of additional payload-aware links per node in the index graph. If not set - regular M parameter will be used.
-   */
+  Number of additional payload-aware links per node in the index graph. If not set - regular M parameter will be used.
+  */
   optional uint64 payload_m = 6;
 }
 
@@ -160,11 +177,11 @@ message WalConfigDiff {
 message OptimizersConfigDiff {
   /*
   The minimal fraction of deleted vectors in a segment, required to perform segment optimization
-   */
+  */
   optional double deleted_threshold = 1;
   /*
   The minimal number of vectors in a segment, required to perform segment optimization
-   */
+  */
   optional uint64 vacuum_min_vector_number = 2;
   /*
   Target amount of segments the optimizer will try to keep.
@@ -181,7 +198,7 @@ message OptimizersConfigDiff {
   Do not create segments larger this size (in kilobytes).
   Large segments might require disproportionately long indexation times,
   therefore it makes sense to limit the size of segments.
-    
+
   If indexing speed is more important - make this parameter lower.
   If search speed is more important - make this parameter higher.
   Note: 1Kb = 1 vector of size 256
@@ -201,11 +218,11 @@ message OptimizersConfigDiff {
   optional uint64 memmap_threshold = 5;
   /*
   Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing
-  
+
   Default value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.
-  
+
   To disable vector indexing, set to `0`.
-  
+
   Note: 1kB = 1 vector of size 256.
   */
   optional uint64 indexing_threshold = 6;
@@ -214,7 +231,10 @@ message OptimizersConfigDiff {
   */
   optional uint64 flush_interval_sec = 7;
   /*
-  Max number of threads, which can be used for optimization. If 0 - `NUM_CPU - 1` will be used
+  Max number of threads (jobs) for running optimizations per shard.
+  Note: each optimization job will also use `max_indexing_threads` threads by itself for index building.
+  If null - have no limit and choose dynamically to saturate CPU.
+  If 0 - no optimization threads, optimizations will be disabled.
   */
   optional uint64 max_optimization_threads = 8;
 }
@@ -343,9 +363,15 @@ message TextIndexParams {
   optional uint64 max_token_len = 4; // Maximal token length
 }
 
+message IntegerIndexParams {
+  bool lookup = 1; // If true - support direct lookups.
+  bool range = 2; // If true - support ranges filters.
+}
+
 message PayloadIndexParams {
   oneof index_params {
     TextIndexParams text_index_params = 1; // Parameters for text index
+    IntegerIndexParams integer_index_params = 2; // Parameters for integer index
   }
 }
 
@@ -423,6 +449,8 @@ enum ReplicaState {
   Initializing = 3; // Collection is being created
   Listener = 4; // A shard which receives data, but is not used for search; Useful for backup shards
   PartialSnapshot = 5; // Snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard
+  Recovery = 6; // Shard is undergoing recovered by an external node; Normally rejects updates, accepts updates if force is true
+  // TODO(1.9): deprecate PartialSnapshot state
 }
 
 message ShardKey {
@@ -468,9 +496,17 @@ message MoveShard {
   optional ShardTransferMethod method = 4;
 }
 
+message RestartTransfer {
+  uint32 shard_id = 1; // Local shard id
+  uint64 from_peer_id = 2;
+  uint64 to_peer_id = 3;
+  ShardTransferMethod method = 4;
+}
+
 enum ShardTransferMethod {
-  StreamRecords = 0;
-  Snapshot = 1;
+  StreamRecords = 0; // Stream shard records in batches
+  Snapshot = 1; // Snapshot the shard and recover it on the target peer
+  WalDelta = 2; // Resolve WAL delta between peers and transfer the difference
 }
 
 message Replica {
@@ -498,6 +534,7 @@ message UpdateCollectionClusterSetupRequest {
     Replica drop_replica = 5;
     CreateShardKey create_shard_key = 7;
     DeleteShardKey delete_shard_key = 8;
+    RestartTransfer restart_transfer = 9;
   }
   optional uint64 timeout = 6; // Wait timeout for operation commit in seconds, if not specified - default value will be supplied
 }

--- a/proto/collections_service.proto
+++ b/proto/collections_service.proto
@@ -8,23 +8,23 @@ option csharp_namespace = "Qdrant.Client.Grpc";
 service Collections {
   /*
   Get detailed information about specified existing collection
-   */
+  */
   rpc Get (GetCollectionInfoRequest) returns (GetCollectionInfoResponse) {}
   /*
   Get list name of all existing collections
-   */
+  */
   rpc List (ListCollectionsRequest) returns (ListCollectionsResponse) {}
   /*
   Create new collection with given parameters
-   */
+  */
   rpc Create (CreateCollection) returns (CollectionOperationResponse) {}
   /*
   Update parameters of the existing collection
-   */
+  */
   rpc Update (UpdateCollection) returns (CollectionOperationResponse) {}
   /*
   Drop collection and all associated data
-   */
+  */
   rpc Delete (DeleteCollection) returns (CollectionOperationResponse) {}
   /*
   Update Aliases of the existing collection
@@ -42,6 +42,10 @@ service Collections {
   Get cluster information for a collection
   */
   rpc CollectionClusterInfo (CollectionClusterInfoRequest) returns (CollectionClusterInfoResponse) {}
+  /*
+  Check the existence of a collection
+  */
+  rpc CollectionExists (CollectionExistsRequest) returns (CollectionExistsResponse) {}
   /*
   Update cluster setup for a collection
   */

--- a/proto/collections_service.proto
+++ b/proto/collections_service.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "collections.proto";
 
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 service Collections {
   /*
@@ -45,4 +46,12 @@ service Collections {
   Update cluster setup for a collection
   */
   rpc UpdateCollectionClusterSetup (UpdateCollectionClusterSetupRequest) returns (UpdateCollectionClusterSetupResponse) {}
+  /*
+  Create shard key
+  */
+  rpc CreateShardKey (CreateShardKeyRequest) returns (CreateShardKeyResponse) {}
+  /*
+  Delete shard key
+  */
+  rpc DeleteShardKey (DeleteShardKeyRequest) returns (DeleteShardKeyResponse) {}
 }

--- a/proto/json_with_int.proto
+++ b/proto/json_with_int.proto
@@ -3,6 +3,7 @@
 syntax = "proto3";
 
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 // `Struct` represents a structured data value, consisting of fields
 // which map to dynamically typed values. In some languages, `Struct`

--- a/proto/points.proto
+++ b/proto/points.proto
@@ -3,8 +3,9 @@ syntax = "proto3";
 package qdrant;
 option csharp_namespace = "Qdrant.Client.Grpc";
 
-import "json_with_int.proto";
 import "collections.proto";
+import "google/protobuf/timestamp.proto";
+import "json_with_int.proto";
 
 
 enum WriteOrderingType {
@@ -118,6 +119,7 @@ message SetPayloadPoints {
   optional PointsSelector points_selector = 5; // Affected points
   optional WriteOrdering ordering = 6; // Write ordering guarantees
   optional ShardKeySelector shard_key_selector = 7; // Option for custom sharding to specify used shard keys
+  optional string key = 8; // Option for indicate property of payload
 }
 
 message DeletePayloadPoints {
@@ -145,6 +147,7 @@ enum FieldType {
   FieldTypeGeo = 3;
   FieldTypeText = 4;
   FieldTypeBool = 5;
+  FieldTypeDatetime = 6;
 }
 
 message CreateFieldIndexCollection {
@@ -204,12 +207,12 @@ message WithVectorsSelector {
 message QuantizationSearchParams {
   /*
   If set to true, search will ignore quantized vector data
-   */
+  */
   optional bool ignore = 1;
 
   /*
   If true, use original vectors to re-score top-k results. If ignored, qdrant decides automatically does rescore enabled or not.
-   */
+  */
   optional bool rescore = 2;
 
   /*
@@ -220,7 +223,7 @@ message QuantizationSearchParams {
 
   For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will be pre-selected using quantized index,
   and then top-100 will be returned after re-scoring.
-   */
+  */
   optional double oversampling = 3;
 }
 
@@ -228,7 +231,7 @@ message SearchParams {
   /*
   Params relevant to HNSW index. Size of the beam in a beam-search.
   Larger the value - more accurate the result, more time required for search.
-   */
+  */
   optional uint64 hnsw_ef = 1;
 
   /*
@@ -244,7 +247,7 @@ message SearchParams {
   If enabled, the engine will only perform search among indexed or small segments.
   Using this option prevents slow searches in case of delayed index, but does not
   guarantee that all uploaded vectors will be included in search results
-   */
+  */
   optional bool indexed_only = 4;
 }
 
@@ -299,6 +302,26 @@ message SearchPointGroups {
   optional SparseIndices sparse_indices = 16;
 }
 
+enum Direction {
+  Asc = 0;
+  Desc = 1;
+}
+
+message StartFrom {
+  oneof value {
+    double float = 1;
+    int64 integer = 2;
+    google.protobuf.Timestamp timestamp = 3;
+    string datetime = 4;
+  }
+}
+
+message OrderBy {
+  string key = 1; // Payload key to order by
+  optional Direction direction = 2; // Ascending or descending order
+  optional StartFrom start_from = 3; // Start from this value
+}
+
 message ScrollPoints {
   string collection_name = 1;
   Filter filter = 2; // Filter conditions - return only those points that satisfy the specified conditions
@@ -309,6 +332,7 @@ message ScrollPoints {
   optional WithVectorsSelector with_vectors = 7; // Options for specifying which vectors to include into response
   optional ReadConsistency read_consistency = 8; // Options for specifying read consistency guarantees
   optional ShardKeySelector shard_key_selector = 9; // Specify in which shards to look for the points, if not specified - look in all shards
+  optional OrderBy order_by = 10; // Order the records by a payload field
 }
 
 // How to use positive and negative vectors to find the results, default is `AverageVector`:
@@ -442,6 +466,7 @@ message PointsUpdateOperation {
       map<string, Value> payload = 1;
       optional PointsSelector points_selector = 2; // Affected points
       optional ShardKeySelector shard_key_selector = 3; // Option for custom sharding to specify used shard keys
+      optional string key = 4; // Option for indicate property of payload
   }
   message DeletePayload {
       repeated string keys = 1;
@@ -623,6 +648,12 @@ message Filter {
   repeated Condition should = 1; // At least one of those conditions should match
   repeated Condition must = 2; // All conditions must match
   repeated Condition must_not = 3; // All conditions must NOT match
+  optional MinShould min_should = 4; // At least minimum amount of given conditions should match 
+}
+
+message MinShould {
+  repeated Condition conditions = 1; 
+  uint64 min_count = 2; 
 }
 
 message Condition {
@@ -661,6 +692,7 @@ message FieldCondition {
   GeoRadius geo_radius = 5; // Check if geo point is within a given radius
   ValuesCount values_count = 6; // Check number of values for a specific field
   GeoPolygon geo_polygon = 7; // Check if geo point is within a given polygon
+  DatetimeRange datetime_range = 8; // Check if datetime is within a given range
 }
 
 message Match {
@@ -689,6 +721,13 @@ message Range {
   optional double gt = 2;
   optional double gte = 3;
   optional double lte = 4;
+}
+
+message DatetimeRange {
+  optional google.protobuf.Timestamp lt = 1;
+  optional google.protobuf.Timestamp gt = 2;
+  optional google.protobuf.Timestamp gte = 3;
+  optional google.protobuf.Timestamp lte = 4;
 }
 
 message GeoBoundingBox {

--- a/proto/points.proto
+++ b/proto/points.proto
@@ -218,6 +218,12 @@ message SearchParams {
   If set to true, search will ignore quantized vector data 
   */
   optional QuantizationSearchParams quantization = 3;
+  /*
+  If enabled, the engine will only perform search among indexed or small segments.
+  Using this option prevents slow searches in case of delayed index, but does not
+  guarantee that all uploaded vectors will be included in search results
+   */
+  optional bool indexed_only = 4;
 }
 
 message SearchPoints {
@@ -325,6 +331,45 @@ message CountPoints {
   string collection_name = 1; // name of the collection
   Filter filter = 2; // Filter conditions - return only those points that satisfy the specified conditions
   optional bool exact = 3; // If `true` - return exact count, if `false` - return approximate count
+}
+
+message PointsUpdateOperation {
+  message PointStructList {
+    repeated PointStruct points = 1;
+  }
+  message SetPayload {
+      map<string, Value> payload = 1;
+      optional PointsSelector points_selector = 2; // Affected points
+  }
+  message DeletePayload {
+      repeated string keys = 1;
+      optional PointsSelector points_selector = 2; // Affected points
+  }
+  message UpdateVectors {
+    repeated PointVectors points = 1; // List of points and vectors to update
+  }
+  message DeleteVectors {
+    PointsSelector points_selector = 1; // Affected points
+    VectorsSelector vectors = 2; // List of vector names to delete
+  }
+
+  oneof operation {
+    PointStructList upsert = 1;
+    PointsSelector delete = 2;
+    SetPayload set_payload = 3;
+    SetPayload overwrite_payload = 4;
+    DeletePayload delete_payload = 5;
+    PointsSelector clear_payload = 6;
+    UpdateVectors update_vectors = 7;
+    DeleteVectors delete_vectors = 8;
+  }
+}
+
+message UpdateBatchPoints {
+  string collection_name = 1; // name of the collection
+  optional bool wait = 2; // Wait until the changes have been applied?
+  repeated PointsUpdateOperation operations = 3;
+  optional WriteOrdering ordering = 4; // Write ordering guarantees
 }
 
 // ---------------------------------------------
@@ -435,6 +480,11 @@ message RecommendBatchResponse {
 
 message RecommendGroupsResponse {
   GroupsResult result = 1;
+  double time = 2; // Time spent to process
+}
+
+message UpdateBatchResponse {
+  repeated UpdateResult result = 1;
   double time = 2; // Time spent to process
 }
 

--- a/proto/points.proto
+++ b/proto/points.proto
@@ -186,7 +186,7 @@ message QuantizationSearchParams {
   optional bool ignore = 1;
 
   /*
-  If true, use original vectors to re-score top-k results. Default is true.
+  If true, use original vectors to re-score top-k results. If ignored, qdrant decides automatically does rescore enabled or not.
    */
   optional bool rescore = 2;
 
@@ -281,6 +281,18 @@ message ScrollPoints {
   optional ReadConsistency read_consistency = 8; // Options for specifying read consistency guarantees
 }
 
+// How to use positive and negative vectors to find the results, default is `AverageVector`:
+enum RecommendStrategy {
+  // Average positive and negative vectors and create a single query with the formula 
+  // `query = avg_pos + avg_pos - avg_neg`. Then performs normal search.
+  AverageVector = 0;
+
+  // Uses custom search objective. Each candidate is compared against all 
+  // examples, its score is then chosen from the `max(max_pos_score, max_neg_score)`. 
+  // If the `max_neg_score` is chosen then it is squared and negated.
+  BestScore = 1;
+}
+
 message LookupLocation {
   string collection_name = 1;
   optional string vector_name = 2; // Which vector to use for search, if not specified - use default vector
@@ -288,8 +300,8 @@ message LookupLocation {
 
 message RecommendPoints {
   string collection_name = 1; // name of the collection
-  repeated PointId positive = 2; // Look for vectors closest to those
-  repeated PointId negative = 3; // Try to avoid vectors like this
+  repeated PointId positive = 2; // Look for vectors closest to the vectors from these points
+  repeated PointId negative = 3; // Try to avoid vectors like the vector from these points
   Filter filter = 4; // Filter conditions - return only those points that satisfy the specified conditions
   uint64 limit = 5; // Max number of result
   reserved 6; // deprecated "with_vector" field
@@ -301,6 +313,9 @@ message RecommendPoints {
   optional WithVectorsSelector with_vectors = 12; // Options for specifying which vectors to include into response
   optional LookupLocation lookup_from = 13; // Name of the collection to use for points lookup, if not specified - use current collection
   optional ReadConsistency read_consistency = 14; // Options for specifying read consistency guarantees
+  optional RecommendStrategy strategy = 16; // How to use the example vectors to find the results
+  repeated Vector positive_vectors = 17; // Look for vectors closest to those
+  repeated Vector negative_vectors = 18; // Try to avoid vectors like this
 }
 
 message RecommendBatchPoints {
@@ -311,8 +326,8 @@ message RecommendBatchPoints {
 
 message RecommendPointGroups {
   string collection_name = 1; // Name of the collection
-  repeated PointId positive = 2; // Look for vectors closest to those
-  repeated PointId negative = 3; // Try to avoid vectors like this
+  repeated PointId positive = 2; // Look for vectors closest to the vectors from these points
+  repeated PointId negative = 3; // Try to avoid vectors like the vector from these points
   Filter filter = 4; // Filter conditions - return only those points that satisfy the specified conditions
   uint32 limit = 5; // Max number of groups in result
   WithPayloadSelector with_payload = 6; // Options for specifying which payload to include or not
@@ -325,6 +340,9 @@ message RecommendPointGroups {
   uint32 group_size = 13; // Maximum amount of points to return per group
   optional ReadConsistency read_consistency = 14; // Options for specifying read consistency guarantees
   optional WithLookup with_lookup = 15; // Options for specifying how to use the group id to lookup points in another collection
+  optional RecommendStrategy strategy = 17; // How to use the example vectors to find the results
+  repeated Vector positive_vectors = 18; // Look for vectors closest to those
+  repeated Vector negative_vectors = 19; // Try to avoid vectors like this
 }
 
 message CountPoints {
@@ -533,7 +551,7 @@ message FieldCondition {
   GeoBoundingBox geo_bounding_box = 4; // Check if points geolocation lies in a given area
   GeoRadius geo_radius = 5; // Check if geo point is within a given radius
   ValuesCount values_count = 6; // Check number of values for a specific field
-  //  GeoPolygon geo_polygon = 7; // Check if geo point is within a given polygon
+  GeoPolygon geo_polygon = 7; // Check if geo point is within a given polygon
 }
 
 message Match {
@@ -574,11 +592,15 @@ message GeoRadius {
   float radius = 2; // In meters
 }
 
+message GeoLineString {
+  repeated GeoPoint points = 1;  // Ordered sequence of GeoPoints representing the line
+}
+
+// For a valid GeoPolygon, both the exterior and interior GeoLineStrings must consist of a minimum of 4 points.
+// Additionally, the first and last points of each GeoLineString must be the same.
 message GeoPolygon {
-  // Ordered list of coordinates representing the vertices of a polygon.
-  // The minimum size is 4, and the first coordinate and the last coordinate
-  // should be the same to form a closed polygon.
-  repeated GeoPoint points = 1;
+  GeoLineString exterior = 1; // The exterior line bounds the surface
+  repeated GeoLineString interiors = 2; // Interior lines (if present) bound holes within the surface
 }
 
 message ValuesCount {

--- a/proto/points.proto
+++ b/proto/points.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 import "json_with_int.proto";
 import "collections.proto";
@@ -40,9 +41,22 @@ message PointId {
   }
 }
 
+message SparseIndices {
+  repeated uint32 data = 1;
+}
+
 message Vector {
   repeated float data = 1;
+  optional SparseIndices indices = 2;
 }
+
+// ---------------------------------------------
+// ----------------- ShardKeySelector ----------
+// ---------------------------------------------
+message ShardKeySelector {
+  repeated ShardKey shard_keys = 1; // List of shard keys which should be used in the request
+}
+
 
 // ---------------------------------------------
 // ---------------- RPC Requests ---------------
@@ -53,6 +67,7 @@ message UpsertPoints {
   optional bool wait = 2; // Wait until the changes have been applied?
   repeated PointStruct points = 3;
   optional WriteOrdering ordering = 4; // Write ordering guarantees
+  optional ShardKeySelector shard_key_selector = 5; // Option for custom sharding to specify used shard keys
 }
 
 message DeletePoints {
@@ -60,6 +75,7 @@ message DeletePoints {
   optional bool wait = 2; // Wait until the changes have been applied?
   PointsSelector points = 3; // Affected points
   optional WriteOrdering ordering = 4; // Write ordering guarantees
+  optional ShardKeySelector shard_key_selector = 5; // Option for custom sharding to specify used shard keys
 }
 
 message GetPoints {
@@ -69,6 +85,7 @@ message GetPoints {
   WithPayloadSelector with_payload = 4; // Options for specifying which payload to include or not
   optional WithVectorsSelector with_vectors = 5; // Options for specifying which vectors to include into response
   optional ReadConsistency read_consistency = 6; // Options for specifying read consistency guarantees
+  optional ShardKeySelector shard_key_selector = 7; // Specify in which shards to look for the points, if not specified - look in all shards
 }
 
 message UpdatePointVectors {
@@ -76,6 +93,7 @@ message UpdatePointVectors {
   optional bool wait = 2; // Wait until the changes have been applied?
   repeated PointVectors points = 3; // List of points and vectors to update
   optional WriteOrdering ordering = 4; // Write ordering guarantees
+  optional ShardKeySelector shard_key_selector = 5; // Option for custom sharding to specify used shard keys
 }
 
 message PointVectors {
@@ -89,6 +107,7 @@ message DeletePointVectors {
   PointsSelector points_selector = 3; // Affected points
   VectorsSelector vectors = 4; // List of vector names to delete
   optional WriteOrdering ordering = 5; // Write ordering guarantees
+  optional ShardKeySelector shard_key_selector = 6; // Option for custom sharding to specify used shard keys
 }
 
 message SetPayloadPoints {
@@ -98,6 +117,7 @@ message SetPayloadPoints {
   reserved 4; // List of point to modify, deprecated
   optional PointsSelector points_selector = 5; // Affected points
   optional WriteOrdering ordering = 6; // Write ordering guarantees
+  optional ShardKeySelector shard_key_selector = 7; // Option for custom sharding to specify used shard keys
 }
 
 message DeletePayloadPoints {
@@ -107,6 +127,7 @@ message DeletePayloadPoints {
   reserved 4; // Affected points, deprecated
   optional PointsSelector points_selector = 5; // Affected points
   optional WriteOrdering ordering = 6; // Write ordering guarantees
+  optional ShardKeySelector shard_key_selector = 7; // Option for custom sharding to specify used shard keys
 }
 
 message ClearPayloadPoints {
@@ -114,6 +135,7 @@ message ClearPayloadPoints {
   optional bool wait = 2; // Wait until the changes have been applied?
   PointsSelector points = 3; // Affected points
   optional WriteOrdering ordering = 4; // Write ordering guarantees
+  optional ShardKeySelector shard_key_selector = 5; // Option for custom sharding to specify used shard keys
 }
 
 enum FieldType {
@@ -239,12 +261,16 @@ message SearchPoints {
   optional string vector_name = 10; // Which vector to use for search, if not specified - use default vector
   optional WithVectorsSelector with_vectors = 11; // Options for specifying which vectors to include into response
   optional ReadConsistency read_consistency = 12; // Options for specifying read consistency guarantees
+  optional uint64 timeout = 13; // If set, overrides global timeout setting for this request. Unit is seconds.
+  optional ShardKeySelector shard_key_selector = 14; // Specify in which shards to look for the points, if not specified - look in all shards
+  optional SparseIndices sparse_indices = 15;
 }
 
 message SearchBatchPoints {
   string collection_name = 1; // Name of the collection
   repeated SearchPoints search_points = 2;
   optional ReadConsistency read_consistency = 3; // Options for specifying read consistency guarantees
+  optional uint64 timeout = 4; // If set, overrides global timeout setting for this request. Unit is seconds.
 }
 
 message WithLookup {
@@ -268,6 +294,9 @@ message SearchPointGroups {
   uint32 group_size = 11; // Maximum amount of points to return per group
   optional ReadConsistency read_consistency = 12; // Options for specifying read consistency guarantees
   optional WithLookup with_lookup = 13; // Options for specifying how to use the group id to lookup points in another collection
+  optional uint64 timeout = 14; // If set, overrides global timeout setting for this request. Unit is seconds.
+  optional ShardKeySelector shard_key_selector = 15; // Specify in which shards to look for the points, if not specified - look in all shards
+  optional SparseIndices sparse_indices = 16;
 }
 
 message ScrollPoints {
@@ -279,6 +308,7 @@ message ScrollPoints {
   WithPayloadSelector with_payload = 6; // Options for specifying which payload to include or not
   optional WithVectorsSelector with_vectors = 7; // Options for specifying which vectors to include into response
   optional ReadConsistency read_consistency = 8; // Options for specifying read consistency guarantees
+  optional ShardKeySelector shard_key_selector = 9; // Specify in which shards to look for the points, if not specified - look in all shards
 }
 
 // How to use positive and negative vectors to find the results, default is `AverageVector`:
@@ -296,6 +326,7 @@ enum RecommendStrategy {
 message LookupLocation {
   string collection_name = 1;
   optional string vector_name = 2; // Which vector to use for search, if not specified - use default vector
+  optional ShardKeySelector shard_key_selector = 3; // Specify in which shards to look for the points, if not specified - look in all shards
 }
 
 message RecommendPoints {
@@ -316,12 +347,15 @@ message RecommendPoints {
   optional RecommendStrategy strategy = 16; // How to use the example vectors to find the results
   repeated Vector positive_vectors = 17; // Look for vectors closest to those
   repeated Vector negative_vectors = 18; // Try to avoid vectors like this
+  optional uint64 timeout = 19; // If set, overrides global timeout setting for this request. Unit is seconds.
+  optional ShardKeySelector shard_key_selector = 20; // Specify in which shards to look for the points, if not specified - look in all shards
 }
 
 message RecommendBatchPoints {
   string collection_name = 1; // Name of the collection
   repeated RecommendPoints recommend_points = 2;
   optional ReadConsistency read_consistency = 3; // Options for specifying read consistency guarantees
+  optional uint64 timeout = 4; // If set, overrides global timeout setting for this request. Unit is seconds.
 }
 
 message RecommendPointGroups {
@@ -343,43 +377,106 @@ message RecommendPointGroups {
   optional RecommendStrategy strategy = 17; // How to use the example vectors to find the results
   repeated Vector positive_vectors = 18; // Look for vectors closest to those
   repeated Vector negative_vectors = 19; // Try to avoid vectors like this
+  optional uint64 timeout = 20; // If set, overrides global timeout setting for this request. Unit is seconds.
+  optional ShardKeySelector shard_key_selector = 21; // Specify in which shards to look for the points, if not specified - look in all shards
+}
+
+message TargetVector {
+  oneof target {
+    VectorExample single = 1;
+    
+    // leaving extensibility for possibly adding multi-target
+  }
+}
+
+message VectorExample {
+  oneof example {
+    PointId id = 1;
+    Vector vector = 2;
+  }
+}
+
+message ContextExamplePair {
+  VectorExample positive = 1;
+  VectorExample negative = 2;
+}
+
+message DiscoverPoints {
+  string collection_name = 1; // name of the collection
+  TargetVector target = 2; // Use this as the primary search objective
+  repeated ContextExamplePair context = 3; // Search will be constrained by these pairs of examples
+  Filter filter = 4; // Filter conditions - return only those points that satisfy the specified conditions
+  uint64 limit = 5; // Max number of result
+  WithPayloadSelector with_payload = 6; // Options for specifying which payload to include or not
+  SearchParams params = 7; // Search config
+  optional uint64 offset = 8; // Offset of the result
+  optional string using = 9; // Define which vector to use for recommendation, if not specified - default vector
+  optional WithVectorsSelector with_vectors = 10; // Options for specifying which vectors to include into response
+  optional LookupLocation lookup_from = 11; // Name of the collection to use for points lookup, if not specified - use current collection
+  optional ReadConsistency read_consistency = 12; // Options for specifying read consistency guarantees
+  optional uint64 timeout = 13; // If set, overrides global timeout setting for this request. Unit is seconds.
+  optional ShardKeySelector shard_key_selector = 14; // Specify in which shards to look for the points, if not specified - look in all shards
+}
+
+message DiscoverBatchPoints {
+  string collection_name = 1; // Name of the collection
+  repeated DiscoverPoints discover_points = 2;
+  optional ReadConsistency read_consistency = 3; // Options for specifying read consistency guarantees
+  optional uint64 timeout = 4; // If set, overrides global timeout setting for this request. Unit is seconds.
 }
 
 message CountPoints {
   string collection_name = 1; // name of the collection
   Filter filter = 2; // Filter conditions - return only those points that satisfy the specified conditions
   optional bool exact = 3; // If `true` - return exact count, if `false` - return approximate count
+  optional ReadConsistency read_consistency = 4; // Options for specifying read consistency guarantees
+  optional ShardKeySelector shard_key_selector = 5; // Specify in which shards to look for the points, if not specified - look in all shards
 }
 
 message PointsUpdateOperation {
   message PointStructList {
     repeated PointStruct points = 1;
+    optional ShardKeySelector shard_key_selector = 2; // Option for custom sharding to specify used shard keys
   }
   message SetPayload {
       map<string, Value> payload = 1;
       optional PointsSelector points_selector = 2; // Affected points
+      optional ShardKeySelector shard_key_selector = 3; // Option for custom sharding to specify used shard keys
   }
   message DeletePayload {
       repeated string keys = 1;
       optional PointsSelector points_selector = 2; // Affected points
+      optional ShardKeySelector shard_key_selector = 3; // Option for custom sharding to specify used shard keys
   }
   message UpdateVectors {
     repeated PointVectors points = 1; // List of points and vectors to update
+    optional ShardKeySelector shard_key_selector = 2; // Option for custom sharding to specify used shard keys
   }
   message DeleteVectors {
     PointsSelector points_selector = 1; // Affected points
     VectorsSelector vectors = 2; // List of vector names to delete
+    optional ShardKeySelector shard_key_selector = 3; // Option for custom sharding to specify used shard keys
+  }
+  message DeletePoints {
+    PointsSelector points = 1; // Affected points
+    optional ShardKeySelector shard_key_selector = 2; // Option for custom sharding to specify used shard keys
+  }
+  message ClearPayload {
+    PointsSelector points = 1; // Affected points
+    optional ShardKeySelector shard_key_selector = 2; // Option for custom sharding to specify used shard keys
   }
 
   oneof operation {
     PointStructList upsert = 1;
-    PointsSelector delete = 2;
+    PointsSelector delete_deprecated = 2 [deprecated=true];
     SetPayload set_payload = 3;
     SetPayload overwrite_payload = 4;
     DeletePayload delete_payload = 5;
-    PointsSelector clear_payload = 6;
+    PointsSelector clear_payload_deprecated = 6 [deprecated=true];
     UpdateVectors update_vectors = 7;
     DeleteVectors delete_vectors = 8;
+    DeletePoints delete_points = 9;
+    ClearPayload clear_payload = 10;
   }
 }
 
@@ -400,7 +497,7 @@ message PointsOperationResponse {
 }
 
 message UpdateResult {
-  uint64 operation_id = 1; // Number of operation
+  optional uint64 operation_id = 1; // Number of operation
   UpdateStatus status = 2; // Operation status
 }
 
@@ -417,6 +514,7 @@ message ScoredPoint {
   reserved 4; // deprecated "vector" field
   uint64 version = 5; // Last update operation applied to this point
   optional Vectors vectors = 6; // Vectors to search
+  optional ShardKey shard_key = 7; // Shard key
 }
 
 message GroupId {
@@ -479,6 +577,7 @@ message RetrievedPoint {
   map<string, Value> payload = 2;
   reserved 3; // deprecated "vector" field
   optional Vectors vectors = 4;
+  optional ShardKey shard_key = 5; // Shard key
 }
 
 message GetResponse {
@@ -492,6 +591,16 @@ message RecommendResponse {
 }
 
 message RecommendBatchResponse {
+  repeated BatchResult result = 1;
+  double time = 2; // Time spent to process
+}
+
+message DiscoverResponse {
+  repeated ScoredPoint result = 1;
+  double time = 2; // Time spent to process
+}
+
+message DiscoverBatchResponse {
   repeated BatchResult result = 1;
   double time = 2; // Time spent to process
 }

--- a/proto/points_service.proto
+++ b/proto/points_service.proto
@@ -8,59 +8,59 @@ option csharp_namespace = "Qdrant.Client.Grpc";
 service Points {
   /*
   Perform insert + updates on points. If a point with a given ID already exists - it will be overwritten.
-   */
+  */
   rpc Upsert (UpsertPoints) returns (PointsOperationResponse) {}
   /*
   Delete points
-   */
+  */
   rpc Delete (DeletePoints) returns (PointsOperationResponse) {}
   /*
   Retrieve points
-   */
+  */
   rpc Get (GetPoints) returns (GetResponse) {}
   /*
   Update named vectors for point
-   */
+  */
   rpc UpdateVectors (UpdatePointVectors) returns (PointsOperationResponse) {}
   /*
   Delete named vectors for points
-   */
+  */
   rpc DeleteVectors (DeletePointVectors) returns (PointsOperationResponse) {}
   /*
   Set payload for points
-   */
+  */
   rpc SetPayload (SetPayloadPoints) returns (PointsOperationResponse) {}
   /*
   Overwrite payload for points
-   */
+  */
   rpc OverwritePayload (SetPayloadPoints) returns (PointsOperationResponse) {}
   /*
   Delete specified key payload for points
-   */
+  */
   rpc DeletePayload (DeletePayloadPoints) returns (PointsOperationResponse) {}
   /*
   Remove all payload for specified points
-   */
+  */
   rpc ClearPayload (ClearPayloadPoints) returns (PointsOperationResponse) {}
   /*
   Create index for field in collection
-   */
+  */
   rpc CreateFieldIndex (CreateFieldIndexCollection) returns (PointsOperationResponse) {}
   /*
   Delete field index for collection
-   */
+  */
   rpc DeleteFieldIndex (DeleteFieldIndexCollection) returns (PointsOperationResponse) {}
   /*
   Retrieve closest points based on vector similarity and given filtering conditions
-   */
+  */
   rpc Search (SearchPoints) returns (SearchResponse) {}
   /*
-   Retrieve closest points based on vector similarity and given filtering conditions
-    */
+  Retrieve closest points based on vector similarity and given filtering conditions
+  */
   rpc SearchBatch (SearchBatchPoints) returns (SearchBatchResponse) {}
   /*
   Retrieve closest points based on vector similarity and given filtering conditions, grouped by a given field
-   */
+  */
   rpc SearchGroups (SearchPointGroups) returns (SearchGroupsResponse) {}
   /*
   Iterate over all or filtered points
@@ -68,19 +68,19 @@ service Points {
   rpc Scroll (ScrollPoints) returns (ScrollResponse) {}
   /*
   Look for the points which are closer to stored positive examples and at the same time further to negative examples.
-   */
+  */
   rpc Recommend (RecommendPoints) returns (RecommendResponse) {}
   /*
   Look for the points which are closer to stored positive examples and at the same time further to negative examples.
-   */
+  */
   rpc RecommendBatch (RecommendBatchPoints) returns (RecommendBatchResponse) {}
   /*
   Look for the points which are closer to stored positive examples and at the same time further to negative examples, grouped by a given field
-   */
+  */
   rpc RecommendGroups (RecommendPointGroups) returns (RecommendGroupsResponse) {}
   /*
   Use context and a target to find the most similar points to the target, constrained by the context.
-        
+
   When using only the context (without a target), a special search - called context search - is performed where
   pairs of points are used to generate a loss that guides the search towards the zone where
   most positive examples overlap. This means that the score minimizes the scenario of
@@ -88,25 +88,25 @@ service Points {
 
   Since the score of a context relates to loss, the maximum score a point can get is 0.0,
   and it becomes normal that many points can have a score of 0.0.
-  
+
   When using target (with or without context), the score behaves a little different: The 
   integer part of the score represents the rank with respect to the context, while the
   decimal part of the score relates to the distance to the target. The context part of the score for 
   each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair, 
   and -1 otherwise.
-   */
+  */
   rpc Discover (DiscoverPoints) returns (DiscoverResponse) {}
   /*
   Batch request points based on { positive, negative } pairs of examples, and/or a target
-   */
+  */
   rpc DiscoverBatch (DiscoverBatchPoints) returns (DiscoverBatchResponse) {}
   /*
-   Count points in collection with given filtering conditions
-   */
+  Count points in collection with given filtering conditions
+  */
   rpc Count (CountPoints) returns (CountResponse) {}
 
   /*
-   Perform multiple update operations in one request
+  Perform multiple update operations in one request
   */
   rpc UpdateBatch (UpdateBatchPoints) returns (UpdateBatchResponse) {}
 }

--- a/proto/points_service.proto
+++ b/proto/points_service.proto
@@ -83,4 +83,9 @@ service Points {
    Count points in collection with given filtering conditions
    */
   rpc Count (CountPoints) returns (CountResponse) {}
+
+  /*
+   Perform multiple update operations in one request
+  */
+  rpc UpdateBatch (UpdateBatchPoints) returns (UpdateBatchResponse) {}
 }

--- a/proto/points_service.proto
+++ b/proto/points_service.proto
@@ -64,7 +64,7 @@ service Points {
    */
   rpc SearchGroups (SearchPointGroups) returns (SearchGroupsResponse) {}
   /*
-  Iterate over all or filtered points points
+  Iterate over all or filtered points
   */
   rpc Scroll (ScrollPoints) returns (ScrollResponse) {}
   /*

--- a/proto/points_service.proto
+++ b/proto/points_service.proto
@@ -3,8 +3,7 @@ syntax = "proto3";
 import "points.proto";
 
 package qdrant;
-
-import "google/protobuf/struct.proto";
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 service Points {
   /*
@@ -75,10 +74,32 @@ service Points {
   Look for the points which are closer to stored positive examples and at the same time further to negative examples.
    */
   rpc RecommendBatch (RecommendBatchPoints) returns (RecommendBatchResponse) {}
-    /*
+  /*
   Look for the points which are closer to stored positive examples and at the same time further to negative examples, grouped by a given field
    */
   rpc RecommendGroups (RecommendPointGroups) returns (RecommendGroupsResponse) {}
+  /*
+  Use context and a target to find the most similar points to the target, constrained by the context.
+        
+  When using only the context (without a target), a special search - called context search - is performed where
+  pairs of points are used to generate a loss that guides the search towards the zone where
+  most positive examples overlap. This means that the score minimizes the scenario of
+  finding a point closer to a negative than to a positive part of a pair.
+
+  Since the score of a context relates to loss, the maximum score a point can get is 0.0,
+  and it becomes normal that many points can have a score of 0.0.
+  
+  When using target (with or without context), the score behaves a little different: The 
+  integer part of the score represents the rank with respect to the context, while the
+  decimal part of the score relates to the distance to the target. The context part of the score for 
+  each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair, 
+  and -1 otherwise.
+   */
+  rpc Discover (DiscoverPoints) returns (DiscoverResponse) {}
+  /*
+  Batch request points based on { positive, negative } pairs of examples, and/or a target
+   */
+  rpc DiscoverBatch (DiscoverBatchPoints) returns (DiscoverBatchResponse) {}
   /*
    Count points in collection with given filtering conditions
    */

--- a/proto/qdrant.proto
+++ b/proto/qdrant.proto
@@ -10,8 +10,7 @@ service Qdrant {
   rpc HealthCheck (HealthCheckRequest) returns (HealthCheckReply) {}
 }
 
-message HealthCheckRequest {
-}
+message HealthCheckRequest {}
 
 message HealthCheckReply {
   string title = 1;

--- a/proto/qdrant.proto
+++ b/proto/qdrant.proto
@@ -16,4 +16,5 @@ message HealthCheckRequest {}
 message HealthCheckReply {
   string title = 1;
   string version = 2;
+  optional string commit = 3;
 }

--- a/proto/qdrant.proto
+++ b/proto/qdrant.proto
@@ -5,6 +5,7 @@ import "points_service.proto";
 import "snapshots_service.proto";
 
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
 service Qdrant {
   rpc HealthCheck (HealthCheckRequest) returns (HealthCheckReply) {}

--- a/proto/snapshots_service.proto
+++ b/proto/snapshots_service.proto
@@ -7,16 +7,16 @@ import "google/protobuf/timestamp.proto";
 
 service Snapshots {
   /*
- Create collection snapshot
+  Create collection snapshot
   */
   rpc Create (CreateSnapshotRequest) returns (CreateSnapshotResponse) {}
   /*
   List collection snapshots
-   */
+  */
   rpc List (ListSnapshotsRequest) returns (ListSnapshotsResponse) {}
   /*
   Delete collection snapshot
-   */
+  */
   rpc Delete (DeleteSnapshotRequest) returns (DeleteSnapshotResponse) {}
   /*
   Create full storage snapshot
@@ -24,11 +24,11 @@ service Snapshots {
   rpc CreateFull (CreateFullSnapshotRequest) returns (CreateSnapshotResponse) {}
   /*
   List full storage snapshots
-   */
+  */
   rpc ListFull (ListFullSnapshotsRequest) returns (ListSnapshotsResponse) {}
   /*
   Delete full storage snapshot
-   */
+  */
   rpc DeleteFull (DeleteFullSnapshotRequest) returns (DeleteSnapshotResponse) {}
 }
 
@@ -57,6 +57,7 @@ message SnapshotDescription {
   string name = 1; // Name of the snapshot
   google.protobuf.Timestamp creation_time = 2; // Creation time of the snapshot
   int64 size = 3; // Size of the snapshot in bytes
+  optional string checksum = 4; // SHA256 digest of the snapshot file
 }
 
 message CreateSnapshotResponse {

--- a/proto/snapshots_service.proto
+++ b/proto/snapshots_service.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
 package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
 
-import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 service Snapshots {
@@ -15,7 +15,7 @@ service Snapshots {
    */
   rpc List (ListSnapshotsRequest) returns (ListSnapshotsResponse) {}
   /*
-  Delete collection snapshots
+  Delete collection snapshot
    */
   rpc Delete (DeleteSnapshotRequest) returns (DeleteSnapshotResponse) {}
   /*
@@ -27,10 +27,9 @@ service Snapshots {
    */
   rpc ListFull (ListFullSnapshotsRequest) returns (ListSnapshotsResponse) {}
   /*
-  List full storage snapshots
+  Delete full storage snapshot
    */
   rpc DeleteFull (DeleteFullSnapshotRequest) returns (DeleteSnapshotResponse) {}
-
 }
 
 message CreateFullSnapshotRequest {}

--- a/src/client.rs
+++ b/src/client.rs
@@ -47,6 +47,7 @@ use tonic::codegen::InterceptedService;
 use tonic::service::Interceptor;
 use tonic::transport::{Channel, Uri};
 use tonic::{Request, Status};
+use url::Url;
 
 pub struct QdrantClientConfig {
     pub uri: String,
@@ -118,8 +119,13 @@ impl AsTimeout for u64 {
 
 impl QdrantClientConfig {
     pub fn from_url(url: &str) -> Self {
+        // Add default port if not present
+        let mut parsed_url = Url::parse(url).unwrap();
+        if parsed_url.port().is_none(){
+            parsed_url.set_port(Some(6334)).unwrap();
+        }
         QdrantClientConfig {
-            uri: url.to_string(),
+            uri: parsed_url.to_string(),
             ..Self::default()
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -266,7 +266,7 @@ impl From<HashMap<String, Vector>> for Vectors {
     fn from(named_vectors: HashMap<String, Vector>) -> Self {
         Vectors {
             vectors_options: Some(VectorsOptions::Vectors(NamedVectors {
-                vectors: named_vectors.into_iter().map(|(k, v)| (k, v)).collect(),
+                vectors: named_vectors.into_iter().collect(),
             })),
         }
     }
@@ -1015,6 +1015,7 @@ impl QdrantClient {
     }
 
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     async fn _set_payload(
         &self,
         collection_name: impl ToString,
@@ -1093,6 +1094,7 @@ impl QdrantClient {
     }
 
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     async fn _overwrite_payload(
         &self,
         collection_name: impl ToString,

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,26 +12,27 @@ use crate::qdrant::with_payload_selector::SelectorOptions;
 use crate::qdrant::{
     qdrant_client, shard_key, with_vectors_selector, AliasOperations, ChangeAliases,
     ClearPayloadPoints, CollectionClusterInfoRequest, CollectionClusterInfoResponse,
-    CollectionOperationResponse, CountPoints, CountResponse, CreateAlias, CreateCollection,
-    CreateFieldIndexCollection, CreateFullSnapshotRequest, CreateShardKey, CreateShardKeyRequest,
-    CreateShardKeyResponse, CreateSnapshotRequest, CreateSnapshotResponse, DeleteAlias,
-    DeleteCollection, DeleteFieldIndexCollection, DeleteFullSnapshotRequest, DeletePayloadPoints,
-    DeletePointVectors, DeletePoints, DeleteShardKey, DeleteShardKeyRequest,
+    CollectionOperationResponse, CollectionParamsDiff, CountPoints, CountResponse, CreateAlias,
+    CreateCollection, CreateFieldIndexCollection, CreateFullSnapshotRequest, CreateShardKey,
+    CreateShardKeyRequest, CreateShardKeyResponse, CreateSnapshotRequest, CreateSnapshotResponse,
+    DeleteAlias, DeleteCollection, DeleteFieldIndexCollection, DeleteFullSnapshotRequest,
+    DeletePayloadPoints, DeletePointVectors, DeletePoints, DeleteShardKey, DeleteShardKeyRequest,
     DeleteShardKeyResponse, DeleteSnapshotRequest, DeleteSnapshotResponse, DiscoverBatchPoints,
     DiscoverBatchResponse, DiscoverPoints, DiscoverResponse, FieldType, GetCollectionInfoRequest,
     GetCollectionInfoResponse, GetPoints, GetResponse, HealthCheckReply, HealthCheckRequest,
-    ListAliasesRequest, ListAliasesResponse, ListCollectionAliasesRequest, ListCollectionsRequest,
-    ListCollectionsResponse, ListFullSnapshotsRequest, ListSnapshotsRequest, ListSnapshotsResponse,
-    ListValue, NamedVectors, OptimizersConfigDiff, PayloadIncludeSelector, PayloadIndexParams,
-    PointId, PointStruct, PointVectors, PointsIdsList, PointsOperationResponse, PointsSelector,
-    PointsUpdateOperation, ReadConsistency, RecommendBatchPoints, RecommendBatchResponse,
-    RecommendGroupsResponse, RecommendPointGroups, RecommendPoints, RecommendResponse, RenameAlias,
-    ScrollPoints, ScrollResponse, SearchBatchPoints, SearchBatchResponse, SearchGroupsResponse,
+    HnswConfigDiff, ListAliasesRequest, ListAliasesResponse, ListCollectionAliasesRequest,
+    ListCollectionsRequest, ListCollectionsResponse, ListFullSnapshotsRequest,
+    ListSnapshotsRequest, ListSnapshotsResponse, ListValue, NamedVectors, OptimizersConfigDiff,
+    PayloadIncludeSelector, PayloadIndexParams, PointId, PointStruct, PointVectors, PointsIdsList,
+    PointsOperationResponse, PointsSelector, PointsUpdateOperation, QuantizationConfigDiff,
+    ReadConsistency, RecommendBatchPoints, RecommendBatchResponse, RecommendGroupsResponse,
+    RecommendPointGroups, RecommendPoints, RecommendResponse, RenameAlias, ScrollPoints,
+    ScrollResponse, SearchBatchPoints, SearchBatchResponse, SearchGroupsResponse,
     SearchPointGroups, SearchPoints, SearchResponse, SetPayloadPoints, ShardKey, ShardKeySelector,
-    SparseIndices, Struct, UpdateBatchPoints, UpdateBatchResponse, UpdateCollection,
-    UpdateCollectionClusterSetupRequest, UpdateCollectionClusterSetupResponse, UpdatePointVectors,
-    UpsertPoints, Value, Vector, Vectors, VectorsSelector, WithPayloadSelector,
-    WithVectorsSelector, WriteOrdering,
+    SparseIndices, SparseVectorConfig, Struct, UpdateBatchPoints, UpdateBatchResponse,
+    UpdateCollection, UpdateCollectionClusterSetupRequest, UpdateCollectionClusterSetupResponse,
+    UpdatePointVectors, UpsertPoints, Value, Vector, Vectors, VectorsConfigDiff, VectorsSelector,
+    WithPayloadSelector, WithVectorsSelector, WriteOrdering,
 };
 use anyhow::Result;
 #[cfg(feature = "serde")]
@@ -506,10 +507,16 @@ impl QdrantClient {
             .await?)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn update_collection(
         &self,
         collection_name: impl ToString,
-        optimizers_config: &OptimizersConfigDiff,
+        optimizers_config: Option<&OptimizersConfigDiff>,
+        params: Option<&CollectionParamsDiff>,
+        sparse_vectors_config: Option<&SparseVectorConfig>,
+        hnsw_config: Option<&HnswConfigDiff>,
+        vectors_config: Option<&VectorsConfigDiff>,
+        quantization_config: Option<&QuantizationConfigDiff>,
     ) -> Result<CollectionOperationResponse> {
         let collection_name = collection_name.to_string();
         let collection_name_ref = collection_name.as_str();
@@ -519,13 +526,13 @@ impl QdrantClient {
                 let result = collection_api
                     .update(UpdateCollection {
                         collection_name: collection_name_ref.to_string(),
-                        optimizers_config: Some(optimizers_config.clone()),
+                        optimizers_config: optimizers_config.cloned(),
                         timeout: None,
-                        params: None,
-                        hnsw_config: None,
-                        vectors_config: None,
-                        quantization_config: None,
-                        sparse_vectors_config: None,
+                        params: params.cloned(),
+                        sparse_vectors_config: sparse_vectors_config.cloned(),
+                        hnsw_config: hnsw_config.cloned(),
+                        vectors_config: vectors_config.cloned(),
+                        quantization_config: quantization_config.cloned(),
                     })
                     .await?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -485,7 +485,7 @@ impl QdrantClient {
             .await?)
     }
 
-    #[deprecated(since = "1.8.0", note = "Please use the `collection_exists` instead")]
+    #[deprecated(since = "1.8.0", note = "Please use `collection_exists` instead")]
     pub async fn has_collection(&self, collection_name: impl ToString) -> Result<bool> {
         let collection_name = collection_name.to_string();
         let response = self.list_collections().await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -978,6 +978,7 @@ impl QdrantClient {
         shard_key_selector: Option<Vec<shard_key::Key>>,
         points: &PointsSelector,
         payload: Payload,
+        payload_key: Option<String>,
         ordering: Option<WriteOrdering>,
     ) -> Result<PointsOperationResponse> {
         self._set_payload(
@@ -985,6 +986,7 @@ impl QdrantClient {
             shard_key_selector,
             points,
             &payload,
+            payload_key,
             false,
             ordering,
         )
@@ -997,6 +999,7 @@ impl QdrantClient {
         shard_key_selector: Option<Vec<shard_key::Key>>,
         points: &PointsSelector,
         payload: Payload,
+        payload_key: Option<String>,
         ordering: Option<WriteOrdering>,
     ) -> Result<PointsOperationResponse> {
         self._set_payload(
@@ -1004,6 +1007,7 @@ impl QdrantClient {
             shard_key_selector,
             points,
             &payload,
+            payload_key,
             true,
             ordering,
         )
@@ -1017,6 +1021,7 @@ impl QdrantClient {
         shard_key_selector: Option<Vec<shard_key::Key>>,
         points: &PointsSelector,
         payload: &Payload,
+        payload_key: Option<String>,
         block: bool,
         ordering: Option<WriteOrdering>,
     ) -> Result<PointsOperationResponse> {
@@ -1025,6 +1030,7 @@ impl QdrantClient {
         let ordering_ref = ordering.as_ref();
         let shard_keys = shard_key_selector.map(ShardKeySelector::from);
         let shard_keys_ref = &shard_keys;
+        let payload_key_ref = payload_key.as_ref();
 
         Ok(self
             .with_points_client(|mut points_api| async move {
@@ -1036,6 +1042,7 @@ impl QdrantClient {
                         points_selector: Some(points.clone()),
                         ordering: ordering_ref.cloned(),
                         shard_key_selector: shard_keys_ref.clone(),
+                        key: payload_key_ref.cloned(),
                     })
                     .await?;
                 Ok(result.into_inner())
@@ -1049,6 +1056,7 @@ impl QdrantClient {
         shard_key_selector: Option<Vec<shard_key::Key>>,
         points: &PointsSelector,
         payload: Payload,
+        payload_key: Option<String>,
         ordering: Option<WriteOrdering>,
     ) -> Result<PointsOperationResponse> {
         self._overwrite_payload(
@@ -1056,6 +1064,7 @@ impl QdrantClient {
             shard_key_selector,
             points,
             &payload,
+            payload_key,
             false,
             ordering,
         )
@@ -1068,6 +1077,7 @@ impl QdrantClient {
         shard_key_selector: Option<Vec<shard_key::Key>>,
         points: &PointsSelector,
         payload: Payload,
+        payload_key: Option<String>,
         ordering: Option<WriteOrdering>,
     ) -> Result<PointsOperationResponse> {
         self._overwrite_payload(
@@ -1075,6 +1085,7 @@ impl QdrantClient {
             shard_key_selector,
             points,
             &payload,
+            payload_key,
             true,
             ordering,
         )
@@ -1088,6 +1099,7 @@ impl QdrantClient {
         shard_key_selector: Option<Vec<shard_key::Key>>,
         points: &PointsSelector,
         payload: &Payload,
+        payload_key: Option<String>,
         block: bool,
         ordering: Option<WriteOrdering>,
     ) -> Result<PointsOperationResponse> {
@@ -1096,6 +1108,7 @@ impl QdrantClient {
         let ordering_ref = ordering.as_ref();
         let shard_keys = shard_key_selector.map(ShardKeySelector::from);
         let shard_keys_ref = &shard_keys;
+        let payload_key_ref = payload_key.as_ref();
 
         Ok(self
             .with_points_client(|mut points_api| async move {
@@ -1107,6 +1120,7 @@ impl QdrantClient {
                         points_selector: Some(points.clone()),
                         ordering: ordering_ref.cloned(),
                         shard_key_selector: shard_keys_ref.clone(),
+                        key: payload_key_ref.cloned(),
                     })
                     .await?;
                 Ok(result.into_inner())

--- a/src/client.rs
+++ b/src/client.rs
@@ -654,7 +654,6 @@ impl QdrantClient {
         let collection_name = collection_name.to_string();
         let collection_name_ref = collection_name.as_str();
         let ordering_ref = ordering.as_ref();
-        let operations = operations.clone();
         Ok(self
             .with_points_client(|mut points_api| async move {
                 Ok(points_api

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,27 @@ use crate::qdrant::update_collection_cluster_setup_request::Operation;
 use crate::qdrant::value::Kind;
 use crate::qdrant::vectors::VectorsOptions;
 use crate::qdrant::with_payload_selector::SelectorOptions;
-use crate::qdrant::{qdrant_client, with_vectors_selector, AliasOperations, ChangeAliases, ClearPayloadPoints, CollectionClusterInfoRequest, CollectionClusterInfoResponse, CollectionOperationResponse, CountPoints, CountResponse, CreateAlias, CreateCollection, CreateFieldIndexCollection, CreateFullSnapshotRequest, CreateSnapshotRequest, CreateSnapshotResponse, DeleteAlias, DeleteCollection, DeleteFieldIndexCollection, DeleteFullSnapshotRequest, DeletePayloadPoints, DeletePointVectors, DeletePoints, DeleteSnapshotRequest, DeleteSnapshotResponse, FieldType, GetCollectionInfoRequest, GetCollectionInfoResponse, GetPoints, GetResponse, HealthCheckReply, HealthCheckRequest, ListAliasesRequest, ListAliasesResponse, ListCollectionAliasesRequest, ListCollectionsRequest, ListCollectionsResponse, ListFullSnapshotsRequest, ListSnapshotsRequest, ListSnapshotsResponse, ListValue, NamedVectors, OptimizersConfigDiff, PayloadIncludeSelector, PayloadIndexParams, PointId, PointStruct, PointVectors, PointsIdsList, PointsOperationResponse, PointsSelector, ReadConsistency, RecommendBatchPoints, RecommendBatchResponse, RecommendGroupsResponse, RecommendPointGroups, RecommendPoints, RecommendResponse, RenameAlias, ScrollPoints, ScrollResponse, SearchBatchPoints, SearchBatchResponse, SearchGroupsResponse, SearchPointGroups, SearchPoints, SearchResponse, SetPayloadPoints, Struct, UpdateCollection, UpdateCollectionClusterSetupRequest, UpdateCollectionClusterSetupResponse, UpdatePointVectors, UpsertPoints, Value, Vector, Vectors, VectorsSelector, WithPayloadSelector, WithVectorsSelector, WriteOrdering, PointsUpdateOperation, UpdateBatchPoints, UpdateBatchResponse};
+use crate::qdrant::{
+    qdrant_client, with_vectors_selector, AliasOperations, ChangeAliases, ClearPayloadPoints,
+    CollectionClusterInfoRequest, CollectionClusterInfoResponse, CollectionOperationResponse,
+    CountPoints, CountResponse, CreateAlias, CreateCollection, CreateFieldIndexCollection,
+    CreateFullSnapshotRequest, CreateSnapshotRequest, CreateSnapshotResponse, DeleteAlias,
+    DeleteCollection, DeleteFieldIndexCollection, DeleteFullSnapshotRequest, DeletePayloadPoints,
+    DeletePointVectors, DeletePoints, DeleteSnapshotRequest, DeleteSnapshotResponse, FieldType,
+    GetCollectionInfoRequest, GetCollectionInfoResponse, GetPoints, GetResponse, HealthCheckReply,
+    HealthCheckRequest, ListAliasesRequest, ListAliasesResponse, ListCollectionAliasesRequest,
+    ListCollectionsRequest, ListCollectionsResponse, ListFullSnapshotsRequest,
+    ListSnapshotsRequest, ListSnapshotsResponse, ListValue, NamedVectors, OptimizersConfigDiff,
+    PayloadIncludeSelector, PayloadIndexParams, PointId, PointStruct, PointVectors, PointsIdsList,
+    PointsOperationResponse, PointsSelector, PointsUpdateOperation, ReadConsistency,
+    RecommendBatchPoints, RecommendBatchResponse, RecommendGroupsResponse, RecommendPointGroups,
+    RecommendPoints, RecommendResponse, RenameAlias, ScrollPoints, ScrollResponse,
+    SearchBatchPoints, SearchBatchResponse, SearchGroupsResponse, SearchPointGroups, SearchPoints,
+    SearchResponse, SetPayloadPoints, Struct, UpdateBatchPoints, UpdateBatchResponse,
+    UpdateCollection, UpdateCollectionClusterSetupRequest, UpdateCollectionClusterSetupResponse,
+    UpdatePointVectors, UpsertPoints, Value, Vector, Vectors, VectorsSelector, WithPayloadSelector,
+    WithVectorsSelector, WriteOrdering,
+};
 use anyhow::Result;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -294,7 +314,7 @@ impl QdrantClient {
         InterceptedService::new(channel, interceptor)
     }
 
-    pub async fn with_snapshot_client<T, O: Future<Output=Result<T, Status>>>(
+    pub async fn with_snapshot_client<T, O: Future<Output = Result<T, Status>>>(
         &self,
         f: impl Fn(SnapshotsClient<InterceptedService<Channel, TokenInterceptor>>) -> O,
     ) -> Result<T, Status> {
@@ -312,7 +332,7 @@ impl QdrantClient {
     }
 
     // Access to raw collection API
-    pub async fn with_collections_client<T, O: Future<Output=Result<T, Status>>>(
+    pub async fn with_collections_client<T, O: Future<Output = Result<T, Status>>>(
         &self,
         f: impl Fn(CollectionsClient<InterceptedService<Channel, TokenInterceptor>>) -> O,
     ) -> Result<T, Status> {
@@ -330,7 +350,7 @@ impl QdrantClient {
     }
 
     // Access to raw points API
-    pub async fn with_points_client<T, O: Future<Output=Result<T, Status>>>(
+    pub async fn with_points_client<T, O: Future<Output = Result<T, Status>>>(
         &self,
         f: impl Fn(PointsClient<InterceptedService<Channel, TokenInterceptor>>) -> O,
     ) -> Result<T, Status> {
@@ -348,7 +368,7 @@ impl QdrantClient {
     }
 
     // Access to raw root qdrant API
-    pub async fn with_root_qdrant_client<T, O: Future<Output=Result<T, Status>>>(
+    pub async fn with_root_qdrant_client<T, O: Future<Output = Result<T, Status>>>(
         &self,
         f: impl Fn(qdrant_client::QdrantClient<InterceptedService<Channel, TokenInterceptor>>) -> O,
     ) -> Result<T, Status> {
@@ -637,13 +657,17 @@ impl QdrantClient {
         let operations = operations.clone();
         Ok(self
             .with_points_client(|mut points_api| async move {
-                Ok(points_api.update_batch(UpdateBatchPoints {
-                    collection_name: collection_name_ref.to_string(),
-                    wait: Some(wait),
-                    operations: operations.to_vec(),
-                    ordering: ordering_ref.cloned(),
-                }).await?.into_inner())
-            }).await?)
+                Ok(points_api
+                    .update_batch(UpdateBatchPoints {
+                        collection_name: collection_name_ref.to_string(),
+                        wait: Some(wait),
+                        operations: operations.to_vec(),
+                        ordering: ordering_ref.cloned(),
+                    })
+                    .await?
+                    .into_inner())
+            })
+            .await?)
     }
 
     pub async fn batch_updates(
@@ -1117,7 +1141,7 @@ impl QdrantClient {
             vector_selector,
             ordering,
         )
-            .await
+        .await
     }
 
     pub async fn delete_vectors_blocking(
@@ -1134,7 +1158,7 @@ impl QdrantClient {
             vector_selector,
             ordering,
         )
-            .await
+        .await
     }
 
     async fn _delete_vectors(
@@ -1262,6 +1286,57 @@ impl QdrantClient {
             .await?)
     }
 
+    /// Perform multiple point, vector and payload insert, update and delete operations in one request.
+    /// This method does *not* wait for completion of the operation, use
+    /// [`update_batch_blocking`] for that.
+    pub async fn update_batch_points(
+        &self,
+        collection_name: impl ToString,
+        operations: &[PointsUpdateOperation],
+        ordering: Option<WriteOrdering>,
+    ) -> Result<UpdateBatchResponse> {
+        self._update_batch_points(collection_name, false, operations, ordering)
+            .await
+    }
+
+    /// Perform multiple point, vector and payload insert, update and delete operations in one request.
+    /// This method waits for completion on each operation.
+    pub async fn update_batch_points_blocking(
+        &self,
+        collection_name: impl ToString,
+        operations: &[PointsUpdateOperation],
+        ordering: Option<WriteOrdering>,
+    ) -> Result<UpdateBatchResponse> {
+        self._update_batch_points(collection_name, true, operations, ordering)
+            .await
+    }
+
+    async fn _update_batch_points(
+        &self,
+        collection_name: impl ToString,
+        blocking: bool,
+        operations: &[PointsUpdateOperation],
+        ordering: Option<WriteOrdering>,
+    ) -> Result<UpdateBatchResponse> {
+        let collection_name = collection_name.to_string();
+        let collection_name_ref = collection_name.as_str();
+        let ordering_ref = ordering.as_ref();
+
+        Ok(self
+            .with_points_client(|mut points_api| async move {
+                let result = points_api
+                    .update_batch(UpdateBatchPoints {
+                        collection_name: collection_name_ref.to_string(),
+                        wait: Some(blocking),
+                        operations: operations.to_owned(),
+                        ordering: ordering_ref.cloned(),
+                    })
+                    .await?;
+                Ok(result.into_inner())
+            })
+            .await?)
+    }
+
     /// Create index for a payload field
     pub async fn _create_field_index(
         &self,
@@ -1311,7 +1386,7 @@ impl QdrantClient {
             false,
             ordering,
         )
-            .await
+        .await
     }
 
     pub async fn create_field_index_blocking(
@@ -1330,7 +1405,7 @@ impl QdrantClient {
             true,
             ordering,
         )
-            .await
+        .await
     }
 
     pub async fn _delete_field_index(
@@ -1485,8 +1560,8 @@ impl QdrantClient {
         snapshot_name: Option<T>,
         rest_api_uri: Option<T>,
     ) -> Result<()>
-        where
-            T: ToString + Clone,
+    where
+        T: ToString + Clone,
     {
         use futures_util::StreamExt;
         use std::io::Write;
@@ -1515,8 +1590,8 @@ impl QdrantClient {
             collection_name.to_string(),
             snapshot_name
         ))
-            .await?
-            .bytes_stream();
+        .await?
+        .bytes_stream();
 
         let out_path = out_path.into();
         let _ = std::fs::remove_file(&out_path);
@@ -1645,8 +1720,8 @@ impl From<Payload> for Value {
 }
 
 impl<T> From<Vec<T>> for Value
-    where
-        T: Into<Value>,
+where
+    T: Into<Value>,
 {
     fn from(val: Vec<T>) -> Self {
         Self {
@@ -1658,8 +1733,8 @@ impl<T> From<Vec<T>> for Value
 }
 
 impl<T> From<Vec<(&str, T)>> for Value
-    where
-        T: Into<Value>,
+where
+    T: Into<Value>,
 {
     fn from(val: Vec<(&str, T)>) -> Self {
         Self {

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -349,7 +349,11 @@ impl From<i64> for MatchValue {
 
 impl From<String> for MatchValue {
     fn from(value: String) -> Self {
-        Self::Keyword(value)
+        if value.contains(char::is_whitespace) {
+            Self::Text(value)
+        } else {
+            Self::Keyword(value)
+        }
     }
 }
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -3,8 +3,9 @@ use crate::qdrant::condition::ConditionOneOf;
 use crate::qdrant::points_selector::PointsSelectorOneOf;
 use crate::qdrant::r#match::MatchValue;
 use crate::qdrant::{
-    Condition, FieldCondition, Filter, GeoBoundingBox, GeoRadius, HasIdCondition, IsEmptyCondition,
-    IsNullCondition, NestedCondition, PointId, PointsSelector, Range, ValuesCount,
+    Condition, FieldCondition, Filter, GeoBoundingBox, GeoPolygon, GeoRadius, HasIdCondition,
+    IsEmptyCondition, IsNullCondition, NestedCondition, PointId, PointsSelector, Range,
+    ValuesCount,
 };
 
 impl From<Filter> for PointsSelector {
@@ -241,6 +242,27 @@ impl qdrant::Condition {
             condition_one_of: Some(ConditionOneOf::Field(qdrant::FieldCondition {
                 key: field.into(),
                 geo_bounding_box: Some(geo_bounding_box),
+                ..Default::default()
+            })),
+        }
+    }
+
+    /// create a Condition that checks geo fields against a geo polygons
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// use qdrant_client::qdrant::{GeoLineString, GeoPoint, GeoPolygon};
+    /// let polygon = GeoPolygon {
+    ///  exterior: Some(GeoLineString { points: vec![GeoPoint { lon: 42., lat: 42. }]}),
+    ///  interiors: vec![],
+    /// };
+    /// qdrant_client::qdrant::Condition::geo_polygon("location", polygon);
+    pub fn geo_polygon(field: impl Into<String>, geo_polygon: GeoPolygon) -> Self {
+        Self {
+            condition_one_of: Some(ConditionOneOf::Field(qdrant::FieldCondition {
+                key: field.into(),
+                geo_polygon: Some(geo_polygon),
                 ..Default::default()
             })),
         }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -1,7 +1,7 @@
 use crate::qdrant::condition::ConditionOneOf;
 use crate::qdrant::points_selector::PointsSelectorOneOf;
 use crate::qdrant::r#match::MatchValue;
-use crate::qdrant::{self, DatetimeRange};
+use crate::qdrant::{self, DatetimeRange, MinShould};
 use crate::qdrant::{
     Condition, FieldCondition, Filter, GeoBoundingBox, GeoPolygon, GeoRadius, HasIdCondition,
     IsEmptyCondition, IsNullCondition, NestedCondition, PointId, PointsSelector, Range,
@@ -91,7 +91,7 @@ impl qdrant::Filter {
             })
     }
 
-    /// create a Filter where all of the conditions must be satisfied
+    /// create a Filter where all the conditions must be satisfied
     pub fn must(conds: impl IntoIterator<Item = qdrant::Condition>) -> Self {
         Self {
             must: conds.into_iter().collect(),
@@ -103,6 +103,17 @@ impl qdrant::Filter {
     pub fn should(conds: impl IntoIterator<Item = qdrant::Condition>) -> Self {
         Self {
             should: conds.into_iter().collect(),
+            ..Default::default()
+        }
+    }
+
+    /// create a Filter where at least a minimum amount of given conditions should be statisfied
+    pub fn min_should(min_count: u64, conds: impl IntoIterator<Item = qdrant::Condition>) -> Self {
+        Self {
+            min_should: Some(MinShould {
+                min_count,
+                conditions: conds.into_iter().collect(),
+            }),
             ..Default::default()
         }
     }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -91,7 +91,7 @@ impl qdrant::Filter {
             })
     }
 
-    /// create a Filter where all the conditions must be satisfied
+    /// Create a [`Filter`] where all the conditions must be satisfied.
     pub fn must(conds: impl IntoIterator<Item = qdrant::Condition>) -> Self {
         Self {
             must: conds.into_iter().collect(),
@@ -99,7 +99,7 @@ impl qdrant::Filter {
         }
     }
 
-    /// create a Filter where at least one of the conditions should be satisfied
+    /// Create a [`Filter`] where at least one of the conditions should be satisfied.
     pub fn should(conds: impl IntoIterator<Item = qdrant::Condition>) -> Self {
         Self {
             should: conds.into_iter().collect(),
@@ -107,7 +107,7 @@ impl qdrant::Filter {
         }
     }
 
-    /// create a Filter where at least a minimum amount of given conditions should be statisfied
+    /// Create a [`Filter`] where at least a minimum amount of given conditions should be statisfied.
     pub fn min_should(min_count: u64, conds: impl IntoIterator<Item = qdrant::Condition>) -> Self {
         Self {
             min_should: Some(MinShould {
@@ -118,7 +118,7 @@ impl qdrant::Filter {
         }
     }
 
-    /// create a Filter where none of the conditions must be satisfied
+    /// Create a [`Filter`] where none of the conditions must be satisfied.
     pub fn must_not(conds: impl IntoIterator<Item = qdrant::Condition>) -> Self {
         Self {
             must_not: conds.into_iter().collect(),
@@ -126,27 +126,30 @@ impl qdrant::Filter {
         }
     }
 
-    /// Alias for [`should`](Self::should)
-    /// create a Filter that matches if any of the conditions match
+    /// Alias for [`should`](Self::should).
+    ///
+    /// Create a [`Filter`] that matches if any of the conditions match.
     pub fn any(conds: impl IntoIterator<Item = qdrant::Condition>) -> Self {
         Self::should(conds)
     }
 
-    /// Alias for [`must`](Self::must)
-    /// create a Filter that matches if all of the conditions match
+    /// Alias for [`must`](Self::must).
+    ///
+    /// Create a [`Filter`] that matches if all of the conditions match.
     pub fn all(conds: impl IntoIterator<Item = qdrant::Condition>) -> Self {
         Self::must(conds)
     }
 
-    /// Alias for [`must_not`](Self::must_not)
-    /// create a Filter that matches if none of the conditions match
+    /// Alias for [`must_not`](Self::must_not).
+    ///
+    /// Create a [`Filter`] that matches if none of the conditions match.
     pub fn none(conds: impl IntoIterator<Item = qdrant::Condition>) -> Self {
         Self::must_not(conds)
     }
 }
 
 impl qdrant::Condition {
-    /// create a Condition to check if a field is empty
+    /// Create a [`Condition`] to check if a field is empty.
     ///
     /// # Examples:
     /// ```
@@ -156,7 +159,7 @@ impl qdrant::Condition {
         Self::from(qdrant::IsEmptyCondition { key: key.into() })
     }
 
-    /// create a Condition to check if the point has a null key
+    /// Create a [`Condition`] to check if the point has a null key.
     ///
     /// # Examples:
     /// ```
@@ -166,7 +169,7 @@ impl qdrant::Condition {
         Self::from(qdrant::IsNullCondition { key: key.into() })
     }
 
-    /// create a Condition to check if the point has one of the given ids
+    /// Create a [`Condition`] to check if the point has one of the given ids.
     ///
     /// # Examples:
     /// ```
@@ -178,7 +181,7 @@ impl qdrant::Condition {
         })
     }
 
-    /// create a Condition that matches a field against a certain value
+    /// Create a [`Condition`] that matches a field against a certain value.
     ///
     /// # Examples:
     /// ```
@@ -197,7 +200,7 @@ impl qdrant::Condition {
         }
     }
 
-    /// create a Condition to initiate full text match
+    /// Create a [`Condition`] to initiate full text match.
     ///
     /// # Examples:
     /// ```
@@ -215,7 +218,7 @@ impl qdrant::Condition {
         }
     }
 
-    /// create a Condition that checks numeric fields against a range
+    /// Create a [`Condition`] that checks numeric fields against a range.
     ///
     /// # Examples:
     ///
@@ -236,7 +239,7 @@ impl qdrant::Condition {
         }
     }
 
-    /// create a Condition that checks datetime fields against a range
+    /// Create a [`Condition`] that checks datetime fields against a range.
     ///
     /// # Examples:
     ///
@@ -258,7 +261,7 @@ impl qdrant::Condition {
         }
     }
 
-    /// create a Condition that checks geo fields against a radius
+    /// Create a [`Condition`] that checks geo fields against a radius.
     ///
     /// # Examples:
     ///
@@ -278,7 +281,7 @@ impl qdrant::Condition {
         }
     }
 
-    /// create a Condition that checks geo fields against a bounding box
+    /// Create a [`Condition`] that checks geo fields against a bounding box.
     ///
     /// # Examples:
     ///
@@ -298,7 +301,7 @@ impl qdrant::Condition {
         }
     }
 
-    /// create a Condition that checks geo fields against a geo polygons
+    /// Create a [`Condition`] that checks geo fields against a geo polygons.
     ///
     /// # Examples:
     ///
@@ -319,7 +322,7 @@ impl qdrant::Condition {
         }
     }
 
-    /// create a Condition that checks count of values in a field
+    /// Create a [`Condition`] that checks count of values in a field.
     ///
     /// # Examples:
     ///
@@ -339,7 +342,7 @@ impl qdrant::Condition {
         }
     }
 
-    /// create a Condition that applies a per-element filter to a nested array
+    /// Create a [`Condition`] that applies a per-element filter to a nested array
     ///
     /// The `field` parameter should be a key-path to a nested array of objects.
     /// You may specify it as both `array_field` or `array_field[]`.
@@ -350,7 +353,7 @@ impl qdrant::Condition {
     /// # Panics:
     ///
     /// If debug assertions are enabled, this will panic if the filter, or any its subfilters,
-    /// contain a `HasIdCondition` (equivalently, a condition created with `Self::has_id`),
+    /// contain a [`HasIdCondition`] (equivalently, a condition created with `Self::has_id`),
     /// as these are unsupported for nested object filters.
     ///
     /// # Examples:

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -186,6 +186,24 @@ impl qdrant::Condition {
         }
     }
 
+    /// create a Condition to initiate full text match
+    ///
+    /// # Examples:
+    /// ```
+    /// qdrant_client::qdrant::Condition::matches_text("description", "good cheap");
+    /// ```
+    pub fn matches_text(field: impl Into<String>, query: impl Into<String>) -> Self {
+        Self {
+            condition_one_of: Some(ConditionOneOf::Field(qdrant::FieldCondition {
+                key: field.into(),
+                r#match: Some(qdrant::Match {
+                    match_value: Some(MatchValue::Text(query.into())),
+                }),
+                ..Default::default()
+            })),
+        }
+    }
+
     /// create a Condition that checks numeric fields against a range
     ///
     /// # Examples:
@@ -331,11 +349,7 @@ impl From<i64> for MatchValue {
 
 impl From<String> for MatchValue {
     fn from(value: String) -> Self {
-        if value.contains(char::is_whitespace) {
-            Self::Text(value)
-        } else {
-            Self::Keyword(value)
-        }
+        Self::Keyword(value)
     }
 }
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -1,7 +1,7 @@
-use crate::qdrant;
 use crate::qdrant::condition::ConditionOneOf;
 use crate::qdrant::points_selector::PointsSelectorOneOf;
 use crate::qdrant::r#match::MatchValue;
+use crate::qdrant::{self, DatetimeRange};
 use crate::qdrant::{
     Condition, FieldCondition, Filter, GeoBoundingBox, GeoPolygon, GeoRadius, HasIdCondition,
     IsEmptyCondition, IsNullCondition, NestedCondition, PointId, PointsSelector, Range,
@@ -220,6 +220,28 @@ impl qdrant::Condition {
             condition_one_of: Some(ConditionOneOf::Field(qdrant::FieldCondition {
                 key: field.into(),
                 range: Some(range),
+                ..Default::default()
+            })),
+        }
+    }
+
+    /// create a Condition that checks datetime fields against a range
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// use qdrant_client::qdrant::DatetimeRange;
+    /// use qdrant_client::Timestamp;
+    /// qdrant_client::qdrant::Condition::datetime_range("timestamp", DatetimeRange {
+    ///     gte: Some(Timestamp::date(2023, 2, 8).unwrap()),
+    ///     ..Default::default()
+    /// });
+    /// ```
+    pub fn datetime_range(field: impl Into<String>, range: DatetimeRange) -> Self {
+        Self {
+            condition_one_of: Some(ConditionOneOf::Field(qdrant::FieldCondition {
+                key: field.into(),
+                datetime_range: Some(range),
                 ..Default::default()
             })),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,6 +520,9 @@ mod tests {
                 vector_name: None,
                 with_vectors: None,
                 read_consistency: None,
+                timeout: None,
+                shard_key_selector: None,
+                sparse_indices: None,
             })
             .await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,6 +487,9 @@ mod tests {
             })
             .await?;
 
+        let exists = client.collection_exists(collection_name).await?;
+        assert!(exists);
+
         let collection_info = client.collection_info(collection_name).await?;
         println!("{:#?}", collection_info);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -550,6 +550,7 @@ mod tests {
                 &vec![0.into()].into(),
                 new_payload,
                 None,
+                None,
             )
             .await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //! };
 //!
 //! let response = qdrant_client
-//!     .upsert_points("my_collection", vec![point], None)
+//!     .upsert_points("my_collection", None, vec![point], None)
 //!     .await?;
 //!# Ok(())
 //!# }
@@ -504,7 +504,7 @@ mod tests {
 
         let points = vec![PointStruct::new(0, vec![12.; 10], payload)];
         client
-            .upsert_points_blocking(collection_name, points, None)
+            .upsert_points_blocking(collection_name, None, points, None)
             .await?;
 
         let search_result = client
@@ -534,13 +534,20 @@ mod tests {
             .collect::<HashMap<_, Value>>()
             .into();
         client
-            .set_payload(collection_name, &vec![0.into()].into(), new_payload, None)
+            .set_payload(
+                collection_name,
+                None,
+                &vec![0.into()].into(),
+                new_payload,
+                None,
+            )
             .await?;
 
         // Delete some payload fields
         client
             .delete_payload_blocking(
                 collection_name,
+                None,
                 &vec![0.into()].into(),
                 vec!["sub_payload".to_string()],
                 None,
@@ -549,7 +556,14 @@ mod tests {
 
         // retrieve points
         let points = client
-            .get_points(collection_name, &[0.into()], Some(true), Some(true), None)
+            .get_points(
+                collection_name,
+                None,
+                &[0.into()],
+                Some(true),
+                Some(true),
+                None,
+            )
             .await?;
 
         assert_eq!(points.result.len(), 1);
@@ -558,7 +572,7 @@ mod tests {
         assert!(!point.payload.contains_key("sub_payload"));
 
         client
-            .delete_points(collection_name, &vec![0.into()].into(), None)
+            .delete_points(collection_name, None, &vec![0.into()].into(), None)
             .await?;
 
         // Access raw point api with client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,9 @@ use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 
+#[doc(no_inline)]
+pub use prost_types::Timestamp;
+
 static NULL_VALUE: Value = Value {
     kind: Some(NullValue(0)),
 };

--- a/src/qdrant.rs
+++ b/src/qdrant.rs
@@ -251,8 +251,15 @@ pub struct ProductQuantization {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BinaryQuantization {
+    /// If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
+    #[prost(bool, optional, tag = "1")]
+    pub always_ram: ::core::option::Option<bool>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QuantizationConfig {
-    #[prost(oneof = "quantization_config::Quantization", tags = "1, 2")]
+    #[prost(oneof = "quantization_config::Quantization", tags = "1, 2, 3")]
     pub quantization: ::core::option::Option<quantization_config::Quantization>,
 }
 /// Nested message and enum types in `QuantizationConfig`.
@@ -264,6 +271,8 @@ pub mod quantization_config {
         Scalar(super::ScalarQuantization),
         #[prost(message, tag = "2")]
         Product(super::ProductQuantization),
+        #[prost(message, tag = "3")]
+        Binary(super::BinaryQuantization),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -272,7 +281,7 @@ pub struct Disabled {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QuantizationConfigDiff {
-    #[prost(oneof = "quantization_config_diff::Quantization", tags = "1, 2, 3")]
+    #[prost(oneof = "quantization_config_diff::Quantization", tags = "1, 2, 3, 4")]
     pub quantization: ::core::option::Option<quantization_config_diff::Quantization>,
 }
 /// Nested message and enum types in `QuantizationConfigDiff`.
@@ -286,6 +295,8 @@ pub mod quantization_config_diff {
         Product(super::ProductQuantization),
         #[prost(message, tag = "3")]
         Disabled(super::Disabled),
+        #[prost(message, tag = "4")]
+        Binary(super::BinaryQuantization),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/src/qdrant.rs
+++ b/src/qdrant.rs
@@ -539,9 +539,9 @@ pub struct CollectionInfo {
     /// status of collection optimizers
     #[prost(message, optional, tag = "2")]
     pub optimizer_status: ::core::option::Option<OptimizerStatus>,
-    /// number of vectors in the collection
-    #[prost(uint64, tag = "3")]
-    pub vectors_count: u64,
+    /// Approximate number of vectors in the collection
+    #[prost(uint64, optional, tag = "3")]
+    pub vectors_count: ::core::option::Option<u64>,
     /// Number of independent segments
     #[prost(uint64, tag = "4")]
     pub segments_count: u64,
@@ -554,10 +554,10 @@ pub struct CollectionInfo {
         ::prost::alloc::string::String,
         PayloadSchemaInfo,
     >,
-    /// number of points in the collection
-    #[prost(uint64, tag = "9")]
-    pub points_count: u64,
-    /// number of indexed vectors in the collection.
+    /// Approximate number of points in the collection
+    #[prost(uint64, optional, tag = "9")]
+    pub points_count: ::core::option::Option<u64>,
+    /// Approximate number of indexed vectors in the collection.
     #[prost(uint64, optional, tag = "10")]
     pub indexed_vectors_count: ::core::option::Option<u64>,
 }

--- a/src/qdrant.rs
+++ b/src/qdrant.rs
@@ -81,6 +81,22 @@ pub mod vectors_config_diff {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SparseVectorParams {
+    /// Configuration of sparse index
+    #[prost(message, optional, tag = "1")]
+    pub index: ::core::option::Option<SparseIndexConfig>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SparseVectorConfig {
+    #[prost(map = "string, message", tag = "1")]
+    pub map: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        SparseVectorParams,
+    >,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetCollectionInfoRequest {
     /// Name of the collection
     #[prost(string, tag = "1")]
@@ -152,6 +168,19 @@ pub struct HnswConfigDiff {
     /// Number of additional payload-aware links per node in the index graph. If not set - regular M parameter will be used.
     #[prost(uint64, optional, tag = "6")]
     pub payload_m: ::core::option::Option<u64>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SparseIndexConfig {
+    ///
+    /// Prefer a full scan search upto (excluding) this number of vectors.
+    /// Note: this is number of vectors, not KiloBytes.
+    #[prost(uint64, optional, tag = "1")]
+    pub full_scan_threshold: ::core::option::Option<u64>,
+    ///
+    /// Store inverted index on disk. If set to false, the index will be stored in RAM.
+    #[prost(bool, optional, tag = "2")]
+    pub on_disk: ::core::option::Option<bool>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -338,6 +367,12 @@ pub struct CreateCollection {
     /// Quantization configuration of vector
     #[prost(message, optional, tag = "14")]
     pub quantization_config: ::core::option::Option<QuantizationConfig>,
+    /// Sharding method
+    #[prost(enumeration = "ShardingMethod", optional, tag = "15")]
+    pub sharding_method: ::core::option::Option<i32>,
+    /// Configuration for sparse vectors
+    #[prost(message, optional, tag = "16")]
+    pub sparse_vectors_config: ::core::option::Option<SparseVectorConfig>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -363,6 +398,9 @@ pub struct UpdateCollection {
     /// Quantization configuration of vector
     #[prost(message, optional, tag = "7")]
     pub quantization_config: ::core::option::Option<QuantizationConfigDiff>,
+    /// New sparse vector parameters
+    #[prost(message, optional, tag = "8")]
+    pub sparse_vectors_config: ::core::option::Option<SparseVectorConfig>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -405,6 +443,12 @@ pub struct CollectionParams {
     /// Fan-out every read request to these many additional remote nodes (and return first available response)
     #[prost(uint32, optional, tag = "8")]
     pub read_fan_out_factor: ::core::option::Option<u32>,
+    /// Sharding method
+    #[prost(enumeration = "ShardingMethod", optional, tag = "9")]
+    pub sharding_method: ::core::option::Option<i32>,
+    /// Configuration for sparse vectors
+    #[prost(message, optional, tag = "10")]
+    pub sparse_vectors_config: ::core::option::Option<SparseVectorConfig>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -611,6 +655,25 @@ pub struct CollectionClusterInfoRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ShardKey {
+    #[prost(oneof = "shard_key::Key", tags = "1, 2")]
+    pub key: ::core::option::Option<shard_key::Key>,
+}
+/// Nested message and enum types in `ShardKey`.
+pub mod shard_key {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Key {
+        /// String key
+        #[prost(string, tag = "1")]
+        Keyword(::prost::alloc::string::String),
+        /// Number key
+        #[prost(uint64, tag = "2")]
+        Number(u64),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LocalShardInfo {
     /// Local shard id
     #[prost(uint32, tag = "1")]
@@ -621,6 +684,9 @@ pub struct LocalShardInfo {
     /// Is replica active
     #[prost(enumeration = "ReplicaState", tag = "3")]
     pub state: i32,
+    /// User-defined shard key
+    #[prost(message, optional, tag = "4")]
+    pub shard_key: ::core::option::Option<ShardKey>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -634,6 +700,9 @@ pub struct RemoteShardInfo {
     /// Is replica active
     #[prost(enumeration = "ReplicaState", tag = "3")]
     pub state: i32,
+    /// User-defined shard key
+    #[prost(message, optional, tag = "4")]
+    pub shard_key: ::core::option::Option<ShardKey>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -678,6 +747,8 @@ pub struct MoveShard {
     pub from_peer_id: u64,
     #[prost(uint64, tag = "3")]
     pub to_peer_id: u64,
+    #[prost(enumeration = "ShardTransferMethod", optional, tag = "4")]
+    pub method: ::core::option::Option<i32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -686,6 +757,29 @@ pub struct Replica {
     pub shard_id: u32,
     #[prost(uint64, tag = "2")]
     pub peer_id: u64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateShardKey {
+    /// User-defined shard key
+    #[prost(message, optional, tag = "1")]
+    pub shard_key: ::core::option::Option<ShardKey>,
+    /// Number of shards to create per shard key
+    #[prost(uint32, optional, tag = "2")]
+    pub shards_number: ::core::option::Option<u32>,
+    /// Number of replicas of each shard to create
+    #[prost(uint32, optional, tag = "3")]
+    pub replication_factor: ::core::option::Option<u32>,
+    /// List of peer ids, allowed to create shards. If empty - all peers are allowed
+    #[prost(uint64, repeated, tag = "4")]
+    pub placement: ::prost::alloc::vec::Vec<u64>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteShardKey {
+    /// Shard key to delete
+    #[prost(message, optional, tag = "1")]
+    pub shard_key: ::core::option::Option<ShardKey>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -698,7 +792,7 @@ pub struct UpdateCollectionClusterSetupRequest {
     pub timeout: ::core::option::Option<u64>,
     #[prost(
         oneof = "update_collection_cluster_setup_request::Operation",
-        tags = "2, 3, 4, 5"
+        tags = "2, 3, 4, 5, 7, 8"
     )]
     pub operation: ::core::option::Option<
         update_collection_cluster_setup_request::Operation,
@@ -717,11 +811,53 @@ pub mod update_collection_cluster_setup_request {
         AbortTransfer(super::MoveShard),
         #[prost(message, tag = "5")]
         DropReplica(super::Replica),
+        #[prost(message, tag = "7")]
+        CreateShardKey(super::CreateShardKey),
+        #[prost(message, tag = "8")]
+        DeleteShardKey(super::DeleteShardKey),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateCollectionClusterSetupResponse {
+    #[prost(bool, tag = "1")]
+    pub result: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateShardKeyRequest {
+    /// Name of the collection
+    #[prost(string, tag = "1")]
+    pub collection_name: ::prost::alloc::string::String,
+    /// Request to create shard key
+    #[prost(message, optional, tag = "2")]
+    pub request: ::core::option::Option<CreateShardKey>,
+    /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+    #[prost(uint64, optional, tag = "3")]
+    pub timeout: ::core::option::Option<u64>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteShardKeyRequest {
+    /// Name of the collection
+    #[prost(string, tag = "1")]
+    pub collection_name: ::prost::alloc::string::String,
+    /// Request to delete shard key
+    #[prost(message, optional, tag = "2")]
+    pub request: ::core::option::Option<DeleteShardKey>,
+    /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+    #[prost(uint64, optional, tag = "3")]
+    pub timeout: ::core::option::Option<u64>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateShardKeyResponse {
+    #[prost(bool, tag = "1")]
+    pub result: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteShardKeyResponse {
     #[prost(bool, tag = "1")]
     pub result: bool,
 }
@@ -732,6 +868,7 @@ pub enum Distance {
     Cosine = 1,
     Euclid = 2,
     Dot = 3,
+    Manhattan = 4,
 }
 impl Distance {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -744,6 +881,7 @@ impl Distance {
             Distance::Cosine => "Cosine",
             Distance::Euclid => "Euclid",
             Distance::Dot => "Dot",
+            Distance::Manhattan => "Manhattan",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -753,6 +891,7 @@ impl Distance {
             "Cosine" => Some(Self::Cosine),
             "Euclid" => Some(Self::Euclid),
             "Dot" => Some(Self::Dot),
+            "Manhattan" => Some(Self::Manhattan),
             _ => None,
         }
     }
@@ -896,6 +1035,34 @@ impl CompressionRatio {
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
+pub enum ShardingMethod {
+    /// Auto-sharding based on record ids
+    Auto = 0,
+    /// Shard by user-defined key
+    Custom = 1,
+}
+impl ShardingMethod {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ShardingMethod::Auto => "Auto",
+            ShardingMethod::Custom => "Custom",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "Auto" => Some(Self::Auto),
+            "Custom" => Some(Self::Custom),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
 pub enum TokenizerType {
     Unknown = 0,
     Prefix = 1,
@@ -942,6 +1109,8 @@ pub enum ReplicaState {
     Initializing = 3,
     /// A shard which receives data, but is not used for search; Useful for backup shards
     Listener = 4,
+    /// Snapshot shard transfer is in progress; Updates should not be sent to (and are ignored by) the shard
+    PartialSnapshot = 5,
 }
 impl ReplicaState {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -955,6 +1124,7 @@ impl ReplicaState {
             ReplicaState::Partial => "Partial",
             ReplicaState::Initializing => "Initializing",
             ReplicaState::Listener => "Listener",
+            ReplicaState::PartialSnapshot => "PartialSnapshot",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -965,6 +1135,33 @@ impl ReplicaState {
             "Partial" => Some(Self::Partial),
             "Initializing" => Some(Self::Initializing),
             "Listener" => Some(Self::Listener),
+            "PartialSnapshot" => Some(Self::PartialSnapshot),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ShardTransferMethod {
+    StreamRecords = 0,
+    Snapshot = 1,
+}
+impl ShardTransferMethod {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ShardTransferMethod::StreamRecords => "StreamRecords",
+            ShardTransferMethod::Snapshot => "Snapshot",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "StreamRecords" => Some(Self::StreamRecords),
+            "Snapshot" => Some(Self::Snapshot),
             _ => None,
         }
     }
@@ -1317,6 +1514,60 @@ pub mod collections_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        ///
+        /// Create shard key
+        pub async fn create_shard_key(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CreateShardKeyRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::CreateShardKeyResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Collections/CreateShardKey",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Collections", "CreateShardKey"));
+            self.inner.unary(req, path, codec).await
+        }
+        ///
+        /// Delete shard key
+        pub async fn delete_shard_key(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeleteShardKeyRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::DeleteShardKeyResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Collections/DeleteShardKey",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Collections", "DeleteShardKey"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -1414,6 +1665,24 @@ pub mod collections_server {
             request: tonic::Request<super::UpdateCollectionClusterSetupRequest>,
         ) -> std::result::Result<
             tonic::Response<super::UpdateCollectionClusterSetupResponse>,
+            tonic::Status,
+        >;
+        ///
+        /// Create shard key
+        async fn create_shard_key(
+            &self,
+            request: tonic::Request<super::CreateShardKeyRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::CreateShardKeyResponse>,
+            tonic::Status,
+        >;
+        ///
+        /// Delete shard key
+        async fn delete_shard_key(
+            &self,
+            request: tonic::Request<super::DeleteShardKeyRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::DeleteShardKeyResponse>,
             tonic::Status,
         >;
     }
@@ -1949,6 +2218,98 @@ pub mod collections_server {
                     };
                     Box::pin(fut)
                 }
+                "/qdrant.Collections/CreateShardKey" => {
+                    #[allow(non_camel_case_types)]
+                    struct CreateShardKeySvc<T: Collections>(pub Arc<T>);
+                    impl<
+                        T: Collections,
+                    > tonic::server::UnaryService<super::CreateShardKeyRequest>
+                    for CreateShardKeySvc<T> {
+                        type Response = super::CreateShardKeyResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::CreateShardKeyRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                (*inner).create_shard_key(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CreateShardKeySvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Collections/DeleteShardKey" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteShardKeySvc<T: Collections>(pub Arc<T>);
+                    impl<
+                        T: Collections,
+                    > tonic::server::UnaryService<super::DeleteShardKeyRequest>
+                    for DeleteShardKeySvc<T> {
+                        type Response = super::DeleteShardKeyResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DeleteShardKeyRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                (*inner).delete_shard_key(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeleteShardKeySvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 _ => {
                     Box::pin(async move {
                         Ok(
@@ -2132,9 +2493,27 @@ pub mod point_id {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SparseIndices {
+    #[prost(uint32, repeated, tag = "1")]
+    pub data: ::prost::alloc::vec::Vec<u32>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Vector {
     #[prost(float, repeated, tag = "1")]
     pub data: ::prost::alloc::vec::Vec<f32>,
+    #[prost(message, optional, tag = "2")]
+    pub indices: ::core::option::Option<SparseIndices>,
+}
+/// ---------------------------------------------
+/// ----------------- ShardKeySelector ----------
+/// ---------------------------------------------
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ShardKeySelector {
+    /// List of shard keys which should be used in the request
+    #[prost(message, repeated, tag = "1")]
+    pub shard_keys: ::prost::alloc::vec::Vec<ShardKey>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2150,6 +2529,9 @@ pub struct UpsertPoints {
     /// Write ordering guarantees
     #[prost(message, optional, tag = "4")]
     pub ordering: ::core::option::Option<WriteOrdering>,
+    /// Option for custom sharding to specify used shard keys
+    #[prost(message, optional, tag = "5")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2166,6 +2548,9 @@ pub struct DeletePoints {
     /// Write ordering guarantees
     #[prost(message, optional, tag = "4")]
     pub ordering: ::core::option::Option<WriteOrdering>,
+    /// Option for custom sharding to specify used shard keys
+    #[prost(message, optional, tag = "5")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2185,6 +2570,9 @@ pub struct GetPoints {
     /// Options for specifying read consistency guarantees
     #[prost(message, optional, tag = "6")]
     pub read_consistency: ::core::option::Option<ReadConsistency>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[prost(message, optional, tag = "7")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2201,6 +2589,9 @@ pub struct UpdatePointVectors {
     /// Write ordering guarantees
     #[prost(message, optional, tag = "4")]
     pub ordering: ::core::option::Option<WriteOrdering>,
+    /// Option for custom sharding to specify used shard keys
+    #[prost(message, optional, tag = "5")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2230,6 +2621,9 @@ pub struct DeletePointVectors {
     /// Write ordering guarantees
     #[prost(message, optional, tag = "5")]
     pub ordering: ::core::option::Option<WriteOrdering>,
+    /// Option for custom sharding to specify used shard keys
+    #[prost(message, optional, tag = "6")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2249,6 +2643,9 @@ pub struct SetPayloadPoints {
     /// Write ordering guarantees
     #[prost(message, optional, tag = "6")]
     pub ordering: ::core::option::Option<WriteOrdering>,
+    /// Option for custom sharding to specify used shard keys
+    #[prost(message, optional, tag = "7")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2268,6 +2665,9 @@ pub struct DeletePayloadPoints {
     /// Write ordering guarantees
     #[prost(message, optional, tag = "6")]
     pub ordering: ::core::option::Option<WriteOrdering>,
+    /// Option for custom sharding to specify used shard keys
+    #[prost(message, optional, tag = "7")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2284,6 +2684,9 @@ pub struct ClearPayloadPoints {
     /// Write ordering guarantees
     #[prost(message, optional, tag = "4")]
     pub ordering: ::core::option::Option<WriteOrdering>,
+    /// Option for custom sharding to specify used shard keys
+    #[prost(message, optional, tag = "5")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2487,6 +2890,14 @@ pub struct SearchPoints {
     /// Options for specifying read consistency guarantees
     #[prost(message, optional, tag = "12")]
     pub read_consistency: ::core::option::Option<ReadConsistency>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[prost(uint64, optional, tag = "13")]
+    pub timeout: ::core::option::Option<u64>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[prost(message, optional, tag = "14")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
+    #[prost(message, optional, tag = "15")]
+    pub sparse_indices: ::core::option::Option<SparseIndices>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2499,6 +2910,9 @@ pub struct SearchBatchPoints {
     /// Options for specifying read consistency guarantees
     #[prost(message, optional, tag = "3")]
     pub read_consistency: ::core::option::Option<ReadConsistency>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[prost(uint64, optional, tag = "4")]
+    pub timeout: ::core::option::Option<u64>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2555,6 +2969,14 @@ pub struct SearchPointGroups {
     /// Options for specifying how to use the group id to lookup points in another collection
     #[prost(message, optional, tag = "13")]
     pub with_lookup: ::core::option::Option<WithLookup>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[prost(uint64, optional, tag = "14")]
+    pub timeout: ::core::option::Option<u64>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[prost(message, optional, tag = "15")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
+    #[prost(message, optional, tag = "16")]
+    pub sparse_indices: ::core::option::Option<SparseIndices>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2579,6 +3001,9 @@ pub struct ScrollPoints {
     /// Options for specifying read consistency guarantees
     #[prost(message, optional, tag = "8")]
     pub read_consistency: ::core::option::Option<ReadConsistency>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[prost(message, optional, tag = "9")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2588,6 +3013,9 @@ pub struct LookupLocation {
     /// Which vector to use for search, if not specified - use default vector
     #[prost(string, optional, tag = "2")]
     pub vector_name: ::core::option::Option<::prost::alloc::string::String>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[prost(message, optional, tag = "3")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2640,6 +3068,12 @@ pub struct RecommendPoints {
     /// Try to avoid vectors like this
     #[prost(message, repeated, tag = "18")]
     pub negative_vectors: ::prost::alloc::vec::Vec<Vector>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[prost(uint64, optional, tag = "19")]
+    pub timeout: ::core::option::Option<u64>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[prost(message, optional, tag = "20")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2652,6 +3086,9 @@ pub struct RecommendBatchPoints {
     /// Options for specifying read consistency guarantees
     #[prost(message, optional, tag = "3")]
     pub read_consistency: ::core::option::Option<ReadConsistency>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[prost(uint64, optional, tag = "4")]
+    pub timeout: ::core::option::Option<u64>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2710,6 +3147,113 @@ pub struct RecommendPointGroups {
     /// Try to avoid vectors like this
     #[prost(message, repeated, tag = "19")]
     pub negative_vectors: ::prost::alloc::vec::Vec<Vector>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[prost(uint64, optional, tag = "20")]
+    pub timeout: ::core::option::Option<u64>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[prost(message, optional, tag = "21")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TargetVector {
+    #[prost(oneof = "target_vector::Target", tags = "1")]
+    pub target: ::core::option::Option<target_vector::Target>,
+}
+/// Nested message and enum types in `TargetVector`.
+pub mod target_vector {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Target {
+        #[prost(message, tag = "1")]
+        Single(super::VectorExample),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct VectorExample {
+    #[prost(oneof = "vector_example::Example", tags = "1, 2")]
+    pub example: ::core::option::Option<vector_example::Example>,
+}
+/// Nested message and enum types in `VectorExample`.
+pub mod vector_example {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Example {
+        #[prost(message, tag = "1")]
+        Id(super::PointId),
+        #[prost(message, tag = "2")]
+        Vector(super::Vector),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ContextExamplePair {
+    #[prost(message, optional, tag = "1")]
+    pub positive: ::core::option::Option<VectorExample>,
+    #[prost(message, optional, tag = "2")]
+    pub negative: ::core::option::Option<VectorExample>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DiscoverPoints {
+    /// name of the collection
+    #[prost(string, tag = "1")]
+    pub collection_name: ::prost::alloc::string::String,
+    /// Use this as the primary search objective
+    #[prost(message, optional, tag = "2")]
+    pub target: ::core::option::Option<TargetVector>,
+    /// Search will be constrained by these pairs of examples
+    #[prost(message, repeated, tag = "3")]
+    pub context: ::prost::alloc::vec::Vec<ContextExamplePair>,
+    /// Filter conditions - return only those points that satisfy the specified conditions
+    #[prost(message, optional, tag = "4")]
+    pub filter: ::core::option::Option<Filter>,
+    /// Max number of result
+    #[prost(uint64, tag = "5")]
+    pub limit: u64,
+    /// Options for specifying which payload to include or not
+    #[prost(message, optional, tag = "6")]
+    pub with_payload: ::core::option::Option<WithPayloadSelector>,
+    /// Search config
+    #[prost(message, optional, tag = "7")]
+    pub params: ::core::option::Option<SearchParams>,
+    /// Offset of the result
+    #[prost(uint64, optional, tag = "8")]
+    pub offset: ::core::option::Option<u64>,
+    /// Define which vector to use for recommendation, if not specified - default vector
+    #[prost(string, optional, tag = "9")]
+    pub using: ::core::option::Option<::prost::alloc::string::String>,
+    /// Options for specifying which vectors to include into response
+    #[prost(message, optional, tag = "10")]
+    pub with_vectors: ::core::option::Option<WithVectorsSelector>,
+    /// Name of the collection to use for points lookup, if not specified - use current collection
+    #[prost(message, optional, tag = "11")]
+    pub lookup_from: ::core::option::Option<LookupLocation>,
+    /// Options for specifying read consistency guarantees
+    #[prost(message, optional, tag = "12")]
+    pub read_consistency: ::core::option::Option<ReadConsistency>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[prost(uint64, optional, tag = "13")]
+    pub timeout: ::core::option::Option<u64>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[prost(message, optional, tag = "14")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DiscoverBatchPoints {
+    /// Name of the collection
+    #[prost(string, tag = "1")]
+    pub collection_name: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "2")]
+    pub discover_points: ::prost::alloc::vec::Vec<DiscoverPoints>,
+    /// Options for specifying read consistency guarantees
+    #[prost(message, optional, tag = "3")]
+    pub read_consistency: ::core::option::Option<ReadConsistency>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[prost(uint64, optional, tag = "4")]
+    pub timeout: ::core::option::Option<u64>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2723,13 +3267,19 @@ pub struct CountPoints {
     /// If `true` - return exact count, if `false` - return approximate count
     #[prost(bool, optional, tag = "3")]
     pub exact: ::core::option::Option<bool>,
+    /// Options for specifying read consistency guarantees
+    #[prost(message, optional, tag = "4")]
+    pub read_consistency: ::core::option::Option<ReadConsistency>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[prost(message, optional, tag = "5")]
+    pub shard_key_selector: ::core::option::Option<ShardKeySelector>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointsUpdateOperation {
     #[prost(
         oneof = "points_update_operation::Operation",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10"
     )]
     pub operation: ::core::option::Option<points_update_operation::Operation>,
 }
@@ -2740,6 +3290,9 @@ pub mod points_update_operation {
     pub struct PointStructList {
         #[prost(message, repeated, tag = "1")]
         pub points: ::prost::alloc::vec::Vec<super::PointStruct>,
+        /// Option for custom sharding to specify used shard keys
+        #[prost(message, optional, tag = "2")]
+        pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
     }
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2752,6 +3305,9 @@ pub mod points_update_operation {
         /// Affected points
         #[prost(message, optional, tag = "2")]
         pub points_selector: ::core::option::Option<super::PointsSelector>,
+        /// Option for custom sharding to specify used shard keys
+        #[prost(message, optional, tag = "3")]
+        pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
     }
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2761,6 +3317,9 @@ pub mod points_update_operation {
         /// Affected points
         #[prost(message, optional, tag = "2")]
         pub points_selector: ::core::option::Option<super::PointsSelector>,
+        /// Option for custom sharding to specify used shard keys
+        #[prost(message, optional, tag = "3")]
+        pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
     }
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2768,6 +3327,9 @@ pub mod points_update_operation {
         /// List of points and vectors to update
         #[prost(message, repeated, tag = "1")]
         pub points: ::prost::alloc::vec::Vec<super::PointVectors>,
+        /// Option for custom sharding to specify used shard keys
+        #[prost(message, optional, tag = "2")]
+        pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
     }
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2778,6 +3340,29 @@ pub mod points_update_operation {
         /// List of vector names to delete
         #[prost(message, optional, tag = "2")]
         pub vectors: ::core::option::Option<super::VectorsSelector>,
+        /// Option for custom sharding to specify used shard keys
+        #[prost(message, optional, tag = "3")]
+        pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
+    }
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct DeletePoints {
+        /// Affected points
+        #[prost(message, optional, tag = "1")]
+        pub points: ::core::option::Option<super::PointsSelector>,
+        /// Option for custom sharding to specify used shard keys
+        #[prost(message, optional, tag = "2")]
+        pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
+    }
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct ClearPayload {
+        /// Affected points
+        #[prost(message, optional, tag = "1")]
+        pub points: ::core::option::Option<super::PointsSelector>,
+        /// Option for custom sharding to specify used shard keys
+        #[prost(message, optional, tag = "2")]
+        pub shard_key_selector: ::core::option::Option<super::ShardKeySelector>,
     }
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -2785,7 +3370,7 @@ pub mod points_update_operation {
         #[prost(message, tag = "1")]
         Upsert(PointStructList),
         #[prost(message, tag = "2")]
-        Delete(super::PointsSelector),
+        DeleteDeprecated(super::PointsSelector),
         #[prost(message, tag = "3")]
         SetPayload(SetPayload),
         #[prost(message, tag = "4")]
@@ -2793,11 +3378,15 @@ pub mod points_update_operation {
         #[prost(message, tag = "5")]
         DeletePayload(DeletePayload),
         #[prost(message, tag = "6")]
-        ClearPayload(super::PointsSelector),
+        ClearPayloadDeprecated(super::PointsSelector),
         #[prost(message, tag = "7")]
         UpdateVectors(UpdateVectors),
         #[prost(message, tag = "8")]
         DeleteVectors(DeleteVectors),
+        #[prost(message, tag = "9")]
+        DeletePoints(DeletePoints),
+        #[prost(message, tag = "10")]
+        ClearPayload(ClearPayload),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2828,8 +3417,8 @@ pub struct PointsOperationResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateResult {
     /// Number of operation
-    #[prost(uint64, tag = "1")]
-    pub operation_id: u64,
+    #[prost(uint64, optional, tag = "1")]
+    pub operation_id: ::core::option::Option<u64>,
     /// Operation status
     #[prost(enumeration = "UpdateStatus", tag = "2")]
     pub status: i32,
@@ -2852,6 +3441,9 @@ pub struct ScoredPoint {
     /// Vectors to search
     #[prost(message, optional, tag = "6")]
     pub vectors: ::core::option::Option<Vectors>,
+    /// Shard key
+    #[prost(message, optional, tag = "7")]
+    pub shard_key: ::core::option::Option<ShardKey>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2964,6 +3556,9 @@ pub struct RetrievedPoint {
     pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
     #[prost(message, optional, tag = "4")]
     pub vectors: ::core::option::Option<Vectors>,
+    /// Shard key
+    #[prost(message, optional, tag = "5")]
+    pub shard_key: ::core::option::Option<ShardKey>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2986,6 +3581,24 @@ pub struct RecommendResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RecommendBatchResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub result: ::prost::alloc::vec::Vec<BatchResult>,
+    /// Time spent to process
+    #[prost(double, tag = "2")]
+    pub time: f64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DiscoverResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub result: ::prost::alloc::vec::Vec<ScoredPoint>,
+    /// Time spent to process
+    #[prost(double, tag = "2")]
+    pub time: f64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DiscoverBatchResponse {
     #[prost(message, repeated, tag = "1")]
     pub result: ::prost::alloc::vec::Vec<BatchResult>,
     /// Time spent to process
@@ -3961,6 +4574,71 @@ pub mod points_client {
             self.inner.unary(req, path, codec).await
         }
         ///
+        /// Use context and a target to find the most similar points to the target, constrained by the context.
+        ///
+        /// When using only the context (without a target), a special search - called context search - is performed where
+        /// pairs of points are used to generate a loss that guides the search towards the zone where
+        /// most positive examples overlap. This means that the score minimizes the scenario of
+        /// finding a point closer to a negative than to a positive part of a pair.
+        ///
+        /// Since the score of a context relates to loss, the maximum score a point can get is 0.0,
+        /// and it becomes normal that many points can have a score of 0.0.
+        ///
+        /// When using target (with or without context), the score behaves a little different: The
+        /// integer part of the score represents the rank with respect to the context, while the
+        /// decimal part of the score relates to the distance to the target. The context part of the score for
+        /// each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair,
+        /// and -1 otherwise.
+        pub async fn discover(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DiscoverPoints>,
+        ) -> std::result::Result<
+            tonic::Response<super::DiscoverResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/qdrant.Points/Discover");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("qdrant.Points", "Discover"));
+            self.inner.unary(req, path, codec).await
+        }
+        ///
+        /// Batch request points based on { positive, negative } pairs of examples, and/or a target
+        pub async fn discover_batch(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DiscoverBatchPoints>,
+        ) -> std::result::Result<
+            tonic::Response<super::DiscoverBatchResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.Points/DiscoverBatch",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("qdrant.Points", "DiscoverBatch"));
+            self.inner.unary(req, path, codec).await
+        }
+        ///
         /// Count points in collection with given filtering conditions
         pub async fn count(
             &mut self,
@@ -4167,6 +4845,38 @@ pub mod points_server {
             request: tonic::Request<super::RecommendPointGroups>,
         ) -> std::result::Result<
             tonic::Response<super::RecommendGroupsResponse>,
+            tonic::Status,
+        >;
+        ///
+        /// Use context and a target to find the most similar points to the target, constrained by the context.
+        ///
+        /// When using only the context (without a target), a special search - called context search - is performed where
+        /// pairs of points are used to generate a loss that guides the search towards the zone where
+        /// most positive examples overlap. This means that the score minimizes the scenario of
+        /// finding a point closer to a negative than to a positive part of a pair.
+        ///
+        /// Since the score of a context relates to loss, the maximum score a point can get is 0.0,
+        /// and it becomes normal that many points can have a score of 0.0.
+        ///
+        /// When using target (with or without context), the score behaves a little different: The
+        /// integer part of the score represents the rank with respect to the context, while the
+        /// decimal part of the score relates to the distance to the target. The context part of the score for
+        /// each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair,
+        /// and -1 otherwise.
+        async fn discover(
+            &self,
+            request: tonic::Request<super::DiscoverPoints>,
+        ) -> std::result::Result<
+            tonic::Response<super::DiscoverResponse>,
+            tonic::Status,
+        >;
+        ///
+        /// Batch request points based on { positive, negative } pairs of examples, and/or a target
+        async fn discover_batch(
+            &self,
+            request: tonic::Request<super::DiscoverBatchPoints>,
+        ) -> std::result::Result<
+            tonic::Response<super::DiscoverBatchResponse>,
             tonic::Status,
         >;
         ///
@@ -5058,6 +5768,94 @@ pub mod points_server {
                     };
                     Box::pin(fut)
                 }
+                "/qdrant.Points/Discover" => {
+                    #[allow(non_camel_case_types)]
+                    struct DiscoverSvc<T: Points>(pub Arc<T>);
+                    impl<T: Points> tonic::server::UnaryService<super::DiscoverPoints>
+                    for DiscoverSvc<T> {
+                        type Response = super::DiscoverResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DiscoverPoints>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).discover(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DiscoverSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.Points/DiscoverBatch" => {
+                    #[allow(non_camel_case_types)]
+                    struct DiscoverBatchSvc<T: Points>(pub Arc<T>);
+                    impl<
+                        T: Points,
+                    > tonic::server::UnaryService<super::DiscoverBatchPoints>
+                    for DiscoverBatchSvc<T> {
+                        type Response = super::DiscoverBatchResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DiscoverBatchPoints>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                (*inner).discover_batch(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DiscoverBatchSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 "/qdrant.Points/Count" => {
                     #[allow(non_camel_case_types)]
                     struct CountSvc<T: Points>(pub Arc<T>);
@@ -5394,7 +6192,7 @@ pub mod snapshots_client {
             self.inner.unary(req, path, codec).await
         }
         ///
-        /// Delete collection snapshots
+        /// Delete collection snapshot
         pub async fn delete(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSnapshotRequest>,
@@ -5471,7 +6269,7 @@ pub mod snapshots_client {
             self.inner.unary(req, path, codec).await
         }
         ///
-        /// List full storage snapshots
+        /// Delete full storage snapshot
         pub async fn delete_full(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteFullSnapshotRequest>,
@@ -5525,7 +6323,7 @@ pub mod snapshots_server {
             tonic::Status,
         >;
         ///
-        /// Delete collection snapshots
+        /// Delete collection snapshot
         async fn delete(
             &self,
             request: tonic::Request<super::DeleteSnapshotRequest>,
@@ -5552,7 +6350,7 @@ pub mod snapshots_server {
             tonic::Status,
         >;
         ///
-        /// List full storage snapshots
+        /// Delete full storage snapshot
         async fn delete_full(
             &self,
             request: tonic::Request<super::DeleteFullSnapshotRequest>,

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -11,7 +11,7 @@ function stop_docker()
 # Ensure current path is project root
 cd "$(dirname "$0")/../"
 
-QDRANT_VERSION='v1.4.0'
+QDRANT_VERSION='v1.5.0'
 
 QDRANT_HOST='localhost:6333'
 

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -11,7 +11,7 @@ function stop_docker()
 # Ensure current path is project root
 cd "$(dirname "$0")/../"
 
-QDRANT_VERSION='v1.6.0'
+QDRANT_VERSION='v1.7.0'
 
 QDRANT_HOST='localhost:6333'
 

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -11,7 +11,7 @@ function stop_docker()
 # Ensure current path is project root
 cd "$(dirname "$0")/../"
 
-QDRANT_VERSION='v1.5.0'
+QDRANT_VERSION='v1.6.0'
 
 QDRANT_HOST='localhost:6333'
 

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -11,7 +11,8 @@ function stop_docker()
 # Ensure current path is project root
 cd "$(dirname "$0")/../"
 
-QDRANT_VERSION='v1.7.0'
+# TODO use v1.8.0
+QDRANT_VERSION='dev'
 
 QDRANT_HOST='localhost:6333'
 

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -11,8 +11,7 @@ function stop_docker()
 # Ensure current path is project root
 cd "$(dirname "$0")/../"
 
-# TODO use v1.8.0
-QDRANT_VERSION='dev'
+QDRANT_VERSION='v1.8.0'
 
 QDRANT_HOST='localhost:6333'
 

--- a/tools/sync_proto.sh
+++ b/tools/sync_proto.sh
@@ -25,6 +25,7 @@ rm $CLIENT_DIR/collections_internal_service.proto
 rm $CLIENT_DIR/qdrant_internal_service.proto
 
 rm $CLIENT_DIR/raft_service.proto
+rm $CLIENT_DIR/shard_snapshots_service.proto
 rm $CLIENT_DIR/health_check.proto
 
 cat $CLIENT_DIR/qdrant.proto \
@@ -32,6 +33,7 @@ cat $CLIENT_DIR/qdrant.proto \
  | grep -v 'points_internal_service.proto' \
  | grep -v 'qdrant_internal_service.proto' \
  | grep -v 'raft_service.proto' \
+ | grep -v 'shard_snapshots_service.proto' \
  | grep -v 'health_check.proto' \
   > $CLIENT_DIR/qdrant_tmp.proto
 

--- a/tools/sync_proto.sh
+++ b/tools/sync_proto.sh
@@ -22,10 +22,13 @@ cp $PROTO_DIR/*.proto $CLIENT_DIR/
 # Remove internal services *.proto
 rm $CLIENT_DIR/points_internal_service.proto
 rm $CLIENT_DIR/collections_internal_service.proto
+rm $CLIENT_DIR/qdrant_internal_service.proto
+
 rm $CLIENT_DIR/raft_service.proto
 cat $CLIENT_DIR/qdrant.proto \
  | grep -v 'collections_internal_service.proto' \
  | grep -v 'points_internal_service.proto' \
+ | grep -v 'qdrant_internal_service.proto' \
  | grep -v 'raft_service.proto' \
   > $CLIENT_DIR/qdrant_tmp.proto
 

--- a/tools/sync_proto.sh
+++ b/tools/sync_proto.sh
@@ -25,11 +25,14 @@ rm $CLIENT_DIR/collections_internal_service.proto
 rm $CLIENT_DIR/qdrant_internal_service.proto
 
 rm $CLIENT_DIR/raft_service.proto
+rm $CLIENT_DIR/health_check.proto
+
 cat $CLIENT_DIR/qdrant.proto \
  | grep -v 'collections_internal_service.proto' \
  | grep -v 'points_internal_service.proto' \
  | grep -v 'qdrant_internal_service.proto' \
  | grep -v 'raft_service.proto' \
+ | grep -v 'health_check.proto' \
   > $CLIENT_DIR/qdrant_tmp.proto
 
 mv $CLIENT_DIR/qdrant_tmp.proto $CLIENT_DIR/qdrant.proto


### PR DESCRIPTION
This commit improves the URL handling mechanism in the QdrantClientConfig's `from_url` function. The primary aim is to ensure that the Qdrant service URL is always fully specified, including a default port if one is not provided in the input URL. This enhancement makes the client's connection setup more robust and error-tolerant, especially in environments where the port might not be explicitly specified.

Changes include:
- Parsing the input URL using the `url` crate to create a `Url` instance.
- Checking for the presence of a port in the parsed URL. If absent, the default port 6334 is assigned.

These modifications ensure that the QdrantClientConfig is initialized with a complete URL, reducing the potential for runtime errors during the client's interaction with the Qdrant service.