### PR TITLE
Begin rust client rewrite - basics & part of new collection builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = { version = "1", optional = true }
 reqwest = { version = "0.11.24", optional = true, default-features = false, features = ["stream", "rustls-tls"] }
 futures-util = { version = "0.3.30", optional = true }
 
+derive_builder = { version = "0.20.0" }
+
 [dev-dependencies]
 tonic-build = { version = "0.9.2", features = ["prost"] }
 tokio = { version = "1.36.0", features = ["rt-multi-thread"] }
@@ -31,6 +33,7 @@ tokio = { version = "1.36.0", features = ["rt-multi-thread"] }
 default = ["download_snapshots", "serde"]
 download_snapshots = ["reqwest", "futures-util"]
 serde = ["dep:serde", "dep:serde_json"]
+new_client = []
 
 [[example]]
 name = "search"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,8 @@ pub mod prelude;
 #[rustfmt::skip]
 pub mod qdrant;
 pub mod filters;
+#[cfg(feature = "new_client")]
+pub mod new_client;
 #[cfg(feature = "serde")]
 pub mod serde;
 

--- a/src/new_client/collection.rs
+++ b/src/new_client/collection.rs
@@ -1,0 +1,204 @@
+#![allow(dead_code)]
+
+use crate::new_client::QdrantClient;
+use crate::prelude::Distance;
+use crate::qdrant::{vectors_config, HnswConfigDiff, VectorParams, VectorParamsMap};
+use derive_builder::Builder;
+use std::collections::HashMap;
+
+pub const DEFAULT_VECTOR_CONFIG_NAME: &str = "default";
+
+#[derive(Builder)]
+#[builder(build_fn(skip))]
+pub struct NewCollection {
+    client: QdrantClient,
+
+    /// Name of the new collection.
+    name: String,
+
+    /// Configuration for vectors.
+    #[builder(default, setter(custom))]
+    vectors: Option<vectors_config::Config>,
+
+    /// Custom params for HNSW index. If not set values from service configuration file are used
+    #[builder(default, setter(strip_option, into))]
+    hnsw_config: Option<HnswConfig>,
+
+    /// If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested.
+    /// This setting saves RAM by (slightly) increasing the response time.
+    /// Note: those payload values that are involved in filtering and are indexed - remain in RAM.
+    #[builder(default, setter(strip_option))]
+    on_disk_payload: Option<bool>,
+}
+
+impl NewCollectionBuilder {
+    pub(crate) fn new(client: QdrantClient, name: impl ToString) -> Self {
+        NewCollectionBuilder {
+            client: Some(client),
+            name: Some(name.to_string()),
+            vectors: None,
+            hnsw_config: None,
+            on_disk_payload: None,
+        }
+    }
+
+    /// Sets the collections default vector configuration.
+    /// Calling this function after `add_vectors_config` will remove all existing configs and only use
+    /// the config provided to this function.
+    pub fn vectors_config(&mut self, config: impl Into<VectorsConfig>) -> &mut Self {
+        self.vectors = Some(Some(vectors_config::Config::Params(config.into().into())));
+        self
+    }
+
+    /// Adds another vector config to the collection. This allows a collection to have multiple vectors
+    /// per record with each different configurations ([See also](https://qdrant.tech/documentation/concepts/collections/#collection-with-multiple-vectors)).
+    ///
+    /// If there has already been a vector config added using `vectors_config` this config gets assigned "default"
+    /// as name.
+    /// Vector configs with the same name will result in the old config being replaced.
+    pub fn add_vectors_config(
+        &mut self,
+        name: impl ToString,
+        config: impl Into<VectorsConfig>,
+    ) -> &mut Self {
+        let new_map = match self.vectors.take().flatten() {
+            Some(vectors_config::Config::Params(single_params)) => {
+                let mut params: HashMap<String, VectorParams> = HashMap::with_capacity(2);
+                params.insert(DEFAULT_VECTOR_CONFIG_NAME.to_string(), single_params);
+                params.insert(name.to_string(), config.into().into());
+                VectorParamsMap { map: params }
+            }
+            Some(vectors_config::Config::ParamsMap(mut params)) => {
+                params.map.insert(name.to_string(), config.into().into());
+                params
+            }
+            None => {
+                let mut params: HashMap<String, VectorParams> = HashMap::with_capacity(1);
+                params.insert(name.to_string(), config.into().into());
+                VectorParamsMap { map: params }
+            }
+        };
+
+        self.vectors = Some(Some(vectors_config::Config::ParamsMap(new_map)));
+
+        self
+    }
+}
+
+#[derive(Builder)]
+#[builder(build_fn(private, error = "std::convert::Infallible", name = "build_inner"))]
+pub struct VectorsConfig {
+    /// Dimension/Size of the vectors.
+    #[builder(default)]
+    size: u64,
+
+    /// The distance to compare vectors.
+    #[builder(default)]
+    distance: Distance,
+
+    /// Whether vectors should be served from disk, improving RAM usage at the cost of latency.
+    #[builder(default, setter(strip_option))]
+    on_disk: Option<bool>,
+
+    /// Custom params for HNSW index. If not set, values from collection configuration are used.
+    #[builder(default, setter(strip_option, into))]
+    hnsw_config: Option<HnswConfig>,
+}
+
+impl From<VectorsConfig> for VectorParams {
+    fn from(value: VectorsConfig) -> Self {
+        Self {
+            size: value.size,
+            distance: value.distance.into(),
+            on_disk: value.on_disk,
+            hnsw_config: value.hnsw_config.map(|i| i.into()),
+            // Todo remove this when all fields were implemented
+            ..Default::default()
+        }
+    }
+}
+
+impl VectorsConfigBuilder {
+    pub fn new(size: u64, distance: Distance) -> Self {
+        Self {
+            size: Some(size),
+            distance: Some(distance),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<VectorsConfigBuilder> for VectorsConfig {
+    fn from(value: VectorsConfigBuilder) -> Self {
+        value.build_inner().unwrap()
+    }
+}
+
+impl From<&mut VectorsConfigBuilder> for VectorsConfig {
+    fn from(value: &mut VectorsConfigBuilder) -> Self {
+        value.clone().build_inner().unwrap()
+    }
+}
+
+#[derive(Builder, Clone)]
+#[builder(build_fn(private, error = "std::convert::Infallible", name = "build_inner"))]
+pub struct HnswConfig {
+    /// Number of edges per node in the index graph. Larger the value - more accurate the search, more space required.
+    #[builder(default, setter(strip_option))]
+    m: Option<u64>,
+
+    /// Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build the index.
+    #[builder(default, setter(strip_option))]
+    ef_construct: Option<u64>,
+
+    /// Minimal size (in kilobytes) of vectors for additional payload-based indexing. If payload chunk is
+    /// smaller than `full_scan_threshold_kb` additional indexing won't be used - in this case full-scan search
+    /// should be preferred by query planner and additional indexing is not required. Note: 1Kb = 1 vector of size 256.
+    #[builder(default, setter(strip_option))]
+    full_scan_threshold: Option<u64>,
+
+    /// Number of parallel threads used for background index building.
+    /// If 0 - automatically select from 8 to 16. Best to keep between 8 and 16 to prevent likelihood
+    /// of building broken/inefficient HNSW graphs. On small CPUs, less threads are used.
+    #[builder(default, setter(strip_option))]
+    max_indexing_threads: Option<u64>,
+
+    /// Store HNSW index on disk. If set to false, the index will be stored in RAM.
+    #[builder(default, setter(strip_option))]
+    on_disk: Option<bool>,
+
+    /// Custom M param for additional payload-aware HNSW links. If not set, default M will be used.
+    #[builder(default, setter(strip_option))]
+    payload_m: Option<u64>,
+}
+
+impl HnswConfigBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl From<HnswConfigBuilder> for HnswConfig {
+    fn from(value: HnswConfigBuilder) -> Self {
+        value.build_inner().unwrap()
+    }
+}
+
+impl From<&mut HnswConfigBuilder> for HnswConfig {
+    fn from(value: &mut HnswConfigBuilder) -> Self {
+        value.clone().build_inner().unwrap()
+    }
+}
+
+impl From<HnswConfig> for HnswConfigDiff {
+    fn from(value: HnswConfig) -> Self {
+        HnswConfigDiff {
+            m: value.m,
+            ef_construct: value.ef_construct,
+            full_scan_threshold: value.full_scan_threshold,
+            max_indexing_threads: value.max_indexing_threads,
+            on_disk: value.on_disk,
+            payload_m: value.payload_m,
+        }
+    }
+}

--- a/src/new_client/config.rs
+++ b/src/new_client/config.rs
@@ -1,0 +1,85 @@
+use crate::client::MaybeApiKey;
+use derive_builder::Builder;
+use std::time::Duration;
+
+pub const DEFAULT_URI: &str = "http://localhost:6334";
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+pub const DEFAULT_KEEP_ALIVE_WHILE_IDLE: bool = true;
+
+/// Configuration for the Qdrant client.
+#[derive(Clone, Debug, Builder)]
+#[builder(build_fn(private, error = "std::convert::Infallible", name = "build_inner"))]
+pub struct ClientConfig {
+    /// The URI of the Qdrant instance to connect to.
+    #[builder(default = "String::from(DEFAULT_URI)", setter(into))]
+    pub uri: String,
+
+    #[builder(default = "DEFAULT_TIMEOUT")]
+    pub timeout: Duration,
+
+    #[builder(default = "DEFAULT_CONNECT_TIMEOUT")]
+    pub connect_timeout: Duration,
+
+    #[builder(default = "DEFAULT_KEEP_ALIVE_WHILE_IDLE")]
+    pub keep_alive_while_idle: bool,
+
+    #[builder(default, setter(custom))]
+    pub api_key: Option<String>,
+}
+
+impl ClientConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn builder() -> ClientConfigBuilder {
+        ClientConfigBuilder::default()
+    }
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        ClientConfigBuilder::default().build()
+    }
+}
+
+impl From<ClientConfigBuilder> for ClientConfig {
+    fn from(mut value: ClientConfigBuilder) -> Self {
+        value.build()
+    }
+}
+
+impl ClientConfigBuilder {
+    pub fn build(&mut self) -> ClientConfig {
+        self.build_inner().unwrap()
+    }
+
+    /// Sets the API key that should be used by the client. This can be anything that
+    /// implements `MaybeApiKey`, so any of `&str`, `String`, `Option<&str>`, `Option<String>`
+    /// or `Result<String>`.
+    ///
+    /// # Examples:
+    ///
+    /// A typical use case might be getting the key from an env var:
+    /// ```rust, no_run
+    /// use qdrant_client::new_client::config::ClientConfig;
+    ///
+    /// let client = ClientConfig::builder().uri("localhost:6334")
+    ///     .api_key(std::env::var("QDRANT_API_KEY"))
+    ///     .build();
+    /// ```
+    /// Another possibility might be getting it out of some config
+    /// ```rust, no_run
+    /// use qdrant_client::new_client::config::ClientConfig;
+    ///# use std::collections::HashMap;
+    ///# let config: HashMap<&str, String> = HashMap::new();
+    /// let client = ClientConfig::builder().uri("localhost:6334")
+    ///     .api_key(config.get("api_key"))
+    ///     .build();
+    /// ```
+    pub fn api_key(&mut self, key: impl MaybeApiKey) -> &mut Self {
+        self.api_key = Some(key.maybe_key());
+        self
+    }
+}

--- a/src/new_client/mod.rs
+++ b/src/new_client/mod.rs
@@ -1,0 +1,118 @@
+pub mod collection;
+pub mod config;
+
+use crate::channel_pool::ChannelPool;
+use crate::client::TokenInterceptor;
+use crate::new_client::config::{ClientConfig, ClientConfigBuilder};
+use crate::qdrant::collections_client::CollectionsClient;
+use crate::qdrant::{ListCollectionsRequest, ListCollectionsResponse};
+use anyhow::Result;
+use std::future::Future;
+use std::sync::Arc;
+use tonic::codegen::InterceptedService;
+use tonic::transport::{Channel, Uri};
+use tonic::Status;
+
+use self::collection::NewCollectionBuilder;
+
+#[derive(Clone)]
+pub struct QdrantClient {
+    pub channel: Arc<ChannelPool>,
+    pub cfg: ClientConfig,
+}
+
+impl QdrantClient {
+    /// Creates a new Qdrant client with the default configuration.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new Qdrant client with a default configuration and a custom url.
+    pub fn from_url(url: impl ToString) -> Result<Self> {
+        let config = ClientConfigBuilder::default().uri(url.to_string()).build();
+        Self::with_config(config)
+    }
+
+    /// Creates a new Qdrant client with a custom config. A [`ClientConfig`] can be built using
+    /// either `ClientConfig::builder()` or `ClientConfigBuilder::default()`.
+    pub fn with_config(config: impl Into<ClientConfig>) -> Result<Self> {
+        let cfg = config.into();
+
+        let channel = ChannelPool::new(
+            cfg.uri.parse::<Uri>()?,
+            cfg.timeout,
+            cfg.connect_timeout,
+            cfg.keep_alive_while_idle,
+        );
+
+        Ok(Self {
+            channel: Arc::new(channel),
+            cfg,
+        })
+    }
+
+    /// Wraps a channel with a token interceptor
+    fn service_with_api_key(
+        &self,
+        channel: Channel,
+    ) -> InterceptedService<Channel, TokenInterceptor> {
+        let interceptor = TokenInterceptor::new(self.cfg.api_key.clone());
+        InterceptedService::new(channel, interceptor)
+    }
+
+    // Access to raw collection API
+    pub async fn with_collections_client<T, O: Future<Output = Result<T, Status>>>(
+        &self,
+        f: impl Fn(CollectionsClient<InterceptedService<Channel, TokenInterceptor>>) -> O,
+    ) -> Result<T, Status> {
+        self.channel
+            .with_channel(
+                |channel| {
+                    let service = self.service_with_api_key(channel);
+                    let client = CollectionsClient::new(service);
+                    let client = client.max_decoding_message_size(usize::MAX);
+                    f(client)
+                },
+                false,
+            )
+            .await
+    }
+
+    pub async fn list_collections(&self) -> Result<ListCollectionsResponse> {
+        let res = self
+            .with_collections_client(|mut ca| async move {
+                let res = ca.list(ListCollectionsRequest {}).await?;
+                Ok(res.into_inner())
+            })
+            .await?;
+        Ok(res)
+    }
+
+    /// Create a new collection. Returns a builder that can be used to configure the new collection.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    ///  use qdrant_client::new_client::collection::VectorsConfigBuilder;
+    ///  use qdrant_client::new_client::QdrantClient;
+    ///  use qdrant_client::qdrant::Distance;
+    ///
+    ///  let client = QdrantClient::new();
+    ///  client
+    ///     .create_collection("my_new_collection")
+    ///     .vectors_config(VectorsConfigBuilder::new(768, Distance::Cosine).on_disk(true))
+    ///     .on_disk_payload(true);
+    /// ```
+    pub fn create_collection(&self, name: impl ToString) -> NewCollectionBuilder {
+        NewCollectionBuilder::new(self.clone(), name)
+    }
+}
+
+impl Default for QdrantClient {
+    fn default() -> Self {
+        let config = ClientConfig::default();
+        // The with_config method only fails if the provided uri is not parsable.
+        // However the uri of the default ClientConfig is a constant in form of a valid uri so this
+        // won't panic.
+        Self::with_config(config).expect("Default uri is not parsable as uri")
+    }
+}


### PR DESCRIPTION
Adds a new separate config, client and a part of a builder pattern to create new collection API requests.
With this implementation, creating a new collection can look as follows
```rust
pub fn new_collection() {
    let client = QdrantClient::new();
    let request = client
        .create_collection("mycollection")
        .vectors_config(VectorsConfigBuilder::new(768, Distance::Cosine).on_disk(true))
        .hnsw_config(HnswConfigBuilder::new().full_scan_threshold(1000))
        .on_disk_payload(true);
    // request.exec().async; (not yet implemented)
}
```

To achieve this, this pr introduces a new crate 'derive_builder' that gets used to automatically generate the builder structures including their setters with their documentation. 
![image](https://github.com/qdrant/rust-client/assets/15957865/0df45157-b55f-4a24-880e-64642d03e5bc)
<br>
The `NewCollection`  builder contains a clone of the `QdrantClient` so we can call request.exec().await later on.