### PR TITLE
Add support for GZip compression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["database", "api-bindings"]
 keywords = ["qdrant", "vector-search", "search-engine", "client", "grpc"]
 
 [dependencies]
-tonic = { version = "0.9.2", features = ["tls", "tls-roots"] }
+tonic = { version = "0.9.2", features = ["tls", "tls-roots", "gzip"] }
 prost = "0.11.9"
 prost-types = "0.11.9"
 anyhow = "1"


### PR DESCRIPTION
This change addresses issue #96.

When evaluating Qdrant performance on test data with medium to large payloads, network overhead became a dominating factor, even with QPS not at crazy-high levels. This should help alleviate this problem, as the payloads are highly compressible.