### PR TITLE
Proposal for new api calling

### DIFF
--- a/src/client/api_callable.rs
+++ b/src/client/api_callable.rs
@@ -1,0 +1,20 @@
+use crate::client::QdrantClient;
+use crate::prelude::CreateCollection;
+use crate::qdrant::CollectionOperationResponse;
+use tonic::async_trait;
+
+#[async_trait]
+pub trait ApiCallable {
+    type Response;
+
+    async fn exec(&self, client: &mut QdrantClient) -> anyhow::Result<Self::Response>;
+}
+
+#[async_trait]
+impl ApiCallable for CreateCollection {
+    type Response = CollectionOperationResponse;
+
+    async fn exec(&self, client: &mut QdrantClient) -> anyhow::Result<Self::Response> {
+        client.create_collection(self).await
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,4 +1,4 @@
-mod api_callable;
+pub mod api_callable;
 pub mod collection;
 pub mod points;
 pub mod snapshot;
@@ -96,8 +96,9 @@ impl QdrantClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prelude::Distance;
-    use crate::qdrant::{CreateCollectionBuilder, HnswConfigDiffBuilder, VectorParamsBuilder};
+    use crate::qdrant::{
+        CreateCollectionBuilder, Distance, HnswConfigDiffBuilder, VectorParamsBuilder,
+    };
 
     const TEST_COLLECTION: &str = "my_test_collection_1234";
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,3 +1,4 @@
+pub use crate::client::api_callable::ApiCallable;
 pub use crate::client::*;
 pub use crate::qdrant::{
     point_id, CreateCollection, DeleteCollection, Distance, PointStruct, SearchPoints, Value,


### PR DESCRIPTION
Proposal for a new way of executing API requests. 
This allows calling the API directly from a built service type like:
```rust
let create_collection = CreateCollectionBuilder::default()
    .collection_name("my_collection")
    .vectors_config(
        VectorParamsBuilder::new(768, Distance::Cosine)
            .hnsw_config(HnswConfigDiffBuilder::default().on_disk(true)),
    )
    .build();
```
and calling with either
```rust
create_collection.exec(&mut client).await?;
```
or
```rust
client.exec(create_collection).await?;
```
