### PR TITLE
Migrate tests to new Qdrant client and fix various issues

### DIFF
--- a/src/grpc_conversions/extensions.rs
+++ b/src/grpc_conversions/extensions.rs
@@ -3,10 +3,14 @@ use crate::prelude::PointStruct;
 use crate::qdrant::{PointId, Vectors};
 
 impl PointStruct {
-    pub fn new(id: impl Into<PointId>, vectors: impl Into<Vectors>, payload: Payload) -> Self {
+    pub fn new(
+        id: impl Into<PointId>,
+        vectors: impl Into<Vectors>,
+        payload: impl Into<Payload>,
+    ) -> Self {
         Self {
             id: Some(id.into()),
-            payload: payload.into(),
+            payload: payload.into().into(),
             vectors: Some(vectors.into()),
         }
     }

--- a/src/grpc_conversions/mod.rs
+++ b/src/grpc_conversions/mod.rs
@@ -443,21 +443,29 @@ impl From<PointsSelectorOneOf> for PointsSelector {
     }
 }
 
-impl From<PointsIdsList> for PointsSelectorOneOf {
-    fn from(value: PointsIdsList) -> Self {
-        Self::Points(value)
-    }
-}
-
 impl From<Filter> for PointsSelectorOneOf {
     fn from(value: Filter) -> Self {
         Self::Filter(value)
     }
 }
 
-impl From<Vec<PointId>> for PointsIdsList {
-    fn from(value: Vec<PointId>) -> Self {
-        Self { ids: value }
+impl<I: Into<PointId>, const N: usize> From<[I; N]> for PointsIdsList {
+    fn from(value: [I; N]) -> Self {
+        let ids: Vec<_> = value.into_iter().map(|i| i.into()).collect();
+        Self { ids }
+    }
+}
+
+impl<I: Into<PointId>> From<Vec<I>> for PointsIdsList {
+    fn from(value: Vec<I>) -> Self {
+        let ids: Vec<_> = value.into_iter().map(|i| i.into()).collect();
+        Self { ids }
+    }
+}
+
+impl<I: Into<PointsIdsList>> From<I> for PointsSelectorOneOf {
+    fn from(value: I) -> Self {
+        Self::Points(value.into())
     }
 }
 

--- a/src/grpc_conversions/primitives.rs
+++ b/src/grpc_conversions/primitives.rs
@@ -323,6 +323,18 @@ impl From<String> for IsNullCondition {
     }
 }
 
+impl From<bool> for with_payload_selector::SelectorOptions {
+    fn from(value: bool) -> Self {
+        Self::Enable(value)
+    }
+}
+
+impl From<bool> for with_vectors_selector::SelectorOptions {
+    fn from(value: bool) -> Self {
+        Self::Enable(value)
+    }
+}
+
 impl<S: Into<String>> From<S> for DeleteCollection {
     fn from(value: S) -> Self {
         DeleteCollectionBuilder::new(value).build()

--- a/src/manual_builder.rs
+++ b/src/manual_builder.rs
@@ -3,386 +3,399 @@
 //! private but for custom type conversions, build() function and constructor with required values we
 //! need access to those private fields. For this reason we introduce a few manually created builder here.
 
-use crate::grpc_macros::builder_type_conversions;
-use crate::qdrant::points_update_operation::{
-    ClearPayload, DeletePayload, DeletePoints, DeleteVectors, OverwritePayload, PointStructList,
-    SetPayload, UpdateVectors,
-};
-use crate::qdrant::{
-    points_selector, PointStruct, PointVectors, PointsSelector, ShardKeySelector, Value,
-    VectorsSelector,
-};
 use derive_builder::Builder;
-use std::collections::HashMap;
 use std::path::PathBuf;
 
-#[derive(Clone)]
-pub struct PointStructListBuilder {
-    points: Vec<PointStruct>,
-    shard_key_selector: Option<ShardKeySelector>,
-}
+/// Builder for service types within qdrant::points_update_operation.
+/// This sub-module is necessary since we do a `use manual_builder::*` in the qdrant.rs file to have
+/// all builder coming from qdrant.rs file in the user API. However there are some builder types here
+/// whichs name is already part of the qdrant.rs module. This submodule prevents ambiguity for those builder.
+pub mod points_update_operation {
+    use crate::grpc_macros::builder_type_conversions;
+    use crate::qdrant::points_update_operation::{
+        ClearPayload, DeletePayload, DeletePoints, DeleteVectors, OverwritePayload,
+        PointStructList, SetPayload, UpdateVectors,
+    };
+    use crate::qdrant::{
+        points_selector, PointStruct, PointVectors, PointsSelector, ShardKeySelector, Value,
+        VectorsSelector,
+    };
+    use std::collections::HashMap;
 
-impl PointStructListBuilder {
-    pub fn new(points: impl Into<Vec<PointStruct>>) -> Self {
-        Self {
-            points: points.into(),
-            shard_key_selector: None,
+    #[derive(Clone)]
+    pub struct PointStructListBuilder {
+        points: Vec<PointStruct>,
+        shard_key_selector: Option<ShardKeySelector>,
+    }
+
+    impl PointStructListBuilder {
+        pub fn new(points: impl Into<Vec<PointStruct>>) -> Self {
+            Self {
+                points: points.into(),
+                shard_key_selector: None,
+            }
+        }
+
+        /// Option for custom sharding to specify used shard keys
+        pub fn shard_key_selector(
+            &mut self,
+            shard_key_selector: impl Into<ShardKeySelector>,
+        ) -> &mut Self {
+            self.shard_key_selector = Some(shard_key_selector.into());
+            self
+        }
+
+        fn build_inner(&self) -> Result<PointStructList, ()> {
+            let builder = self.clone();
+            Ok(PointStructList {
+                points: builder.points,
+                shard_key_selector: builder.shard_key_selector,
+            })
         }
     }
 
-    /// Option for custom sharding to specify used shard keys
-    pub fn shard_key_selector(
-        &mut self,
-        shard_key_selector: impl Into<ShardKeySelector>,
-    ) -> &mut Self {
-        self.shard_key_selector = Some(shard_key_selector.into());
-        self
+    builder_type_conversions!(PointStructList, PointStructListBuilder);
+
+    #[derive(Clone)]
+    pub struct SetPayloadBuilder {
+        payload: HashMap<String, Value>,
+        points_selector: Option<PointsSelector>,
+        shard_key_selector: Option<ShardKeySelector>,
+        key: Option<String>,
     }
 
-    fn build_inner(&self) -> Result<PointStructList, ()> {
-        let builder = self.clone();
-        Ok(PointStructList {
-            points: builder.points,
-            shard_key_selector: builder.shard_key_selector,
-        })
-    }
-}
+    impl SetPayloadBuilder {
+        pub fn new(payload: impl Into<HashMap<String, Value>>) -> Self {
+            Self {
+                payload: payload.into(),
+                points_selector: None,
+                shard_key_selector: None,
+                key: None,
+            }
+        }
 
-builder_type_conversions!(PointStructList, PointStructListBuilder);
+        /// Affected points
+        pub fn points_selector(
+            &mut self,
+            points_selector: impl Into<points_selector::PointsSelectorOneOf>,
+        ) -> &mut Self {
+            self.points_selector = Some(PointsSelector {
+                points_selector_one_of: Some(points_selector.into()),
+            });
+            self
+        }
 
-#[derive(Clone)]
-pub struct SetPayloadBuilder {
-    payload: HashMap<String, Value>,
-    points_selector: Option<PointsSelector>,
-    shard_key_selector: Option<ShardKeySelector>,
-    key: Option<String>,
-}
+        /// Option for custom sharding to specify used shard keys
+        pub fn shard_key_selector(
+            &mut self,
+            shard_key_selector: impl Into<ShardKeySelector>,
+        ) -> &mut Self {
+            self.shard_key_selector = Some(shard_key_selector.into());
+            self
+        }
 
-impl SetPayloadBuilder {
-    pub fn new(payload: impl Into<HashMap<String, Value>>) -> Self {
-        Self {
-            payload: payload.into(),
-            points_selector: None,
-            shard_key_selector: None,
-            key: None,
+        /// Option for indicate property of payload
+        pub fn key(&mut self, key: impl Into<String>) -> &mut Self {
+            self.key = Some(key.into());
+            self
+        }
+
+        fn build_inner(&self) -> Result<SetPayload, ()> {
+            let builder = self.clone();
+            Ok(SetPayload {
+                payload: builder.payload,
+                points_selector: builder.points_selector,
+                shard_key_selector: builder.shard_key_selector,
+                key: builder.key,
+            })
         }
     }
 
-    /// Affected points
-    pub fn points_selector(
-        &mut self,
-        points_selector: impl Into<points_selector::PointsSelectorOneOf>,
-    ) -> &mut Self {
-        self.points_selector = Some(PointsSelector {
-            points_selector_one_of: Some(points_selector.into()),
-        });
-        self
+    builder_type_conversions!(SetPayload, SetPayloadBuilder);
+
+    #[derive(Clone)]
+    pub struct OverwritePayloadBuilder {
+        payload: HashMap<String, Value>,
+        points_selector: Option<PointsSelector>,
+        shard_key_selector: Option<ShardKeySelector>,
+        key: Option<String>,
     }
 
-    /// Option for custom sharding to specify used shard keys
-    pub fn shard_key_selector(
-        &mut self,
-        shard_key_selector: impl Into<ShardKeySelector>,
-    ) -> &mut Self {
-        self.shard_key_selector = Some(shard_key_selector.into());
-        self
-    }
+    impl OverwritePayloadBuilder {
+        pub fn new(payload: impl Into<HashMap<String, Value>>) -> Self {
+            Self {
+                payload: payload.into(),
+                points_selector: None,
+                shard_key_selector: None,
+                key: None,
+            }
+        }
 
-    /// Option for indicate property of payload
-    pub fn key(&mut self, key: impl Into<String>) -> &mut Self {
-        self.key = Some(key.into());
-        self
-    }
+        /// Affected points
+        pub fn points_selector(
+            &mut self,
+            points_selector: impl Into<points_selector::PointsSelectorOneOf>,
+        ) -> &mut Self {
+            self.points_selector = Some(PointsSelector {
+                points_selector_one_of: Some(points_selector.into()),
+            });
+            self
+        }
 
-    fn build_inner(&self) -> Result<SetPayload, ()> {
-        let builder = self.clone();
-        Ok(SetPayload {
-            payload: builder.payload,
-            points_selector: builder.points_selector,
-            shard_key_selector: builder.shard_key_selector,
-            key: builder.key,
-        })
-    }
-}
+        /// Option for custom sharding to specify used shard keys
+        pub fn shard_key_selector(
+            &mut self,
+            shard_key_selector: impl Into<ShardKeySelector>,
+        ) -> &mut Self {
+            self.shard_key_selector = Some(shard_key_selector.into());
+            self
+        }
 
-builder_type_conversions!(SetPayload, SetPayloadBuilder);
+        /// Option for indicate property of payload
+        pub fn key(&mut self, key: impl Into<String>) -> &mut Self {
+            self.key = Some(key.into());
+            self
+        }
 
-#[derive(Clone)]
-pub struct OverwritePayloadBuilder {
-    payload: HashMap<String, Value>,
-    points_selector: Option<PointsSelector>,
-    shard_key_selector: Option<ShardKeySelector>,
-    key: Option<String>,
-}
-
-impl OverwritePayloadBuilder {
-    pub fn new(payload: impl Into<HashMap<String, Value>>) -> Self {
-        Self {
-            payload: payload.into(),
-            points_selector: None,
-            shard_key_selector: None,
-            key: None,
+        fn build_inner(&self) -> Result<OverwritePayload, ()> {
+            let builder = self.clone();
+            Ok(OverwritePayload {
+                payload: builder.payload,
+                points_selector: builder.points_selector,
+                shard_key_selector: builder.shard_key_selector,
+                key: builder.key,
+            })
         }
     }
 
-    /// Affected points
-    pub fn points_selector(
-        &mut self,
-        points_selector: impl Into<points_selector::PointsSelectorOneOf>,
-    ) -> &mut Self {
-        self.points_selector = Some(PointsSelector {
-            points_selector_one_of: Some(points_selector.into()),
-        });
-        self
+    builder_type_conversions!(OverwritePayload, OverwritePayloadBuilder);
+
+    #[derive(Clone)]
+    pub struct DeletePayloadBuilder {
+        keys: Vec<String>,
+        points_selector: Option<PointsSelector>,
+        shard_key_selector: Option<ShardKeySelector>,
     }
 
-    /// Option for custom sharding to specify used shard keys
-    pub fn shard_key_selector(
-        &mut self,
-        shard_key_selector: impl Into<ShardKeySelector>,
-    ) -> &mut Self {
-        self.shard_key_selector = Some(shard_key_selector.into());
-        self
-    }
+    impl DeletePayloadBuilder {
+        pub fn new(keys: impl Into<Vec<String>>) -> Self {
+            Self {
+                keys: keys.into(),
+                points_selector: None,
+                shard_key_selector: None,
+            }
+        }
 
-    /// Option for indicate property of payload
-    pub fn key(&mut self, key: impl Into<String>) -> &mut Self {
-        self.key = Some(key.into());
-        self
-    }
+        /// Affected points
+        pub fn points_selector(
+            &mut self,
+            points_selector: impl Into<points_selector::PointsSelectorOneOf>,
+        ) -> &mut Self {
+            self.points_selector = Some(PointsSelector {
+                points_selector_one_of: Some(points_selector.into()),
+            });
+            self
+        }
 
-    fn build_inner(&self) -> Result<OverwritePayload, ()> {
-        let builder = self.clone();
-        Ok(OverwritePayload {
-            payload: builder.payload,
-            points_selector: builder.points_selector,
-            shard_key_selector: builder.shard_key_selector,
-            key: builder.key,
-        })
-    }
-}
+        /// Option for custom sharding to specify used shard keys
+        pub fn shard_key_selector(
+            &mut self,
+            shard_key_selector: impl Into<ShardKeySelector>,
+        ) -> &mut Self {
+            self.shard_key_selector = Some(shard_key_selector.into());
+            self
+        }
 
-builder_type_conversions!(OverwritePayload, OverwritePayloadBuilder);
-
-#[derive(Clone)]
-pub struct DeletePayloadBuilder {
-    keys: Vec<String>,
-    points_selector: Option<PointsSelector>,
-    shard_key_selector: Option<ShardKeySelector>,
-}
-
-impl DeletePayloadBuilder {
-    pub fn new(keys: impl Into<Vec<String>>) -> Self {
-        Self {
-            keys: keys.into(),
-            points_selector: None,
-            shard_key_selector: None,
+        fn build_inner(&self) -> Result<DeletePayload, ()> {
+            let builder = self.clone();
+            Ok(DeletePayload {
+                keys: builder.keys,
+                points_selector: builder.points_selector,
+                shard_key_selector: builder.shard_key_selector,
+            })
         }
     }
 
-    /// Affected points
-    pub fn points_selector(
-        &mut self,
-        points_selector: impl Into<points_selector::PointsSelectorOneOf>,
-    ) -> &mut Self {
-        self.points_selector = Some(PointsSelector {
-            points_selector_one_of: Some(points_selector.into()),
-        });
-        self
+    builder_type_conversions!(DeletePayload, DeletePayloadBuilder);
+
+    #[derive(Clone)]
+    pub struct UpdateVectorsBuilder {
+        points: Vec<PointVectors>,
+        shard_key_selector: Option<ShardKeySelector>,
     }
 
-    /// Option for custom sharding to specify used shard keys
-    pub fn shard_key_selector(
-        &mut self,
-        shard_key_selector: impl Into<ShardKeySelector>,
-    ) -> &mut Self {
-        self.shard_key_selector = Some(shard_key_selector.into());
-        self
-    }
+    impl UpdateVectorsBuilder {
+        pub fn new(points: impl Into<Vec<PointVectors>>) -> Self {
+            Self {
+                points: points.into(),
+                shard_key_selector: None,
+            }
+        }
 
-    fn build_inner(&self) -> Result<DeletePayload, ()> {
-        let builder = self.clone();
-        Ok(DeletePayload {
-            keys: builder.keys,
-            points_selector: builder.points_selector,
-            shard_key_selector: builder.shard_key_selector,
-        })
-    }
-}
+        /// Option for custom sharding to specify used shard keys
+        pub fn shard_key_selector(
+            &mut self,
+            shard_key_selector: impl Into<ShardKeySelector>,
+        ) -> &mut Self {
+            self.shard_key_selector = Some(shard_key_selector.into());
+            self
+        }
 
-builder_type_conversions!(DeletePayload, DeletePayloadBuilder);
-
-#[derive(Clone)]
-pub struct UpdateVectorsBuilder {
-    points: Vec<PointVectors>,
-    shard_key_selector: Option<ShardKeySelector>,
-}
-
-impl UpdateVectorsBuilder {
-    pub fn new(points: impl Into<Vec<PointVectors>>) -> Self {
-        Self {
-            points: points.into(),
-            shard_key_selector: None,
+        fn build_inner(&self) -> Result<UpdateVectors, ()> {
+            let builder = self.clone();
+            Ok(UpdateVectors {
+                points: builder.points,
+                shard_key_selector: builder.shard_key_selector,
+            })
         }
     }
 
-    /// Option for custom sharding to specify used shard keys
-    pub fn shard_key_selector(
-        &mut self,
-        shard_key_selector: impl Into<ShardKeySelector>,
-    ) -> &mut Self {
-        self.shard_key_selector = Some(shard_key_selector.into());
-        self
+    builder_type_conversions!(UpdateVectors, UpdateVectorsBuilder);
+
+    #[derive(Clone, Default)]
+    pub struct DeleteVectorsBuilder {
+        points_selector: Option<PointsSelector>,
+        vectors: Option<VectorsSelector>,
+        shard_key_selector: Option<ShardKeySelector>,
     }
 
-    fn build_inner(&self) -> Result<UpdateVectors, ()> {
-        let builder = self.clone();
-        Ok(UpdateVectors {
-            points: builder.points,
-            shard_key_selector: builder.shard_key_selector,
-        })
-    }
-}
+    impl DeleteVectorsBuilder {
+        pub fn new() -> Self {
+            Self {
+                points_selector: None,
+                vectors: None,
+                shard_key_selector: None,
+            }
+        }
 
-builder_type_conversions!(UpdateVectors, UpdateVectorsBuilder);
+        /// Affected points
+        pub fn points_selector(
+            &mut self,
+            points_selector: impl Into<points_selector::PointsSelectorOneOf>,
+        ) -> &mut Self {
+            self.points_selector = Some(PointsSelector {
+                points_selector_one_of: Some(points_selector.into()),
+            });
+            self
+        }
 
-#[derive(Clone, Default)]
-pub struct DeleteVectorsBuilder {
-    points_selector: Option<PointsSelector>,
-    vectors: Option<VectorsSelector>,
-    shard_key_selector: Option<ShardKeySelector>,
-}
+        /// List of vector names to delete
+        pub fn vectors(&mut self, vectors: impl Into<VectorsSelector>) -> &mut Self {
+            self.vectors = Some(vectors.into());
+            self
+        }
 
-impl DeleteVectorsBuilder {
-    pub fn new() -> Self {
-        Self {
-            points_selector: None,
-            vectors: None,
-            shard_key_selector: None,
+        /// Option for custom sharding to specify used shard keys
+        pub fn shard_key_selector(
+            &mut self,
+            shard_key_selector: impl Into<ShardKeySelector>,
+        ) -> &mut Self {
+            self.shard_key_selector = Some(shard_key_selector.into());
+            self
+        }
+
+        fn build_inner(&self) -> Result<DeleteVectors, ()> {
+            let builder = self.clone();
+            Ok(DeleteVectors {
+                points_selector: builder.points_selector,
+                vectors: builder.vectors,
+                shard_key_selector: builder.shard_key_selector,
+            })
         }
     }
 
-    /// Affected points
-    pub fn points_selector(
-        &mut self,
-        points_selector: impl Into<points_selector::PointsSelectorOneOf>,
-    ) -> &mut Self {
-        self.points_selector = Some(PointsSelector {
-            points_selector_one_of: Some(points_selector.into()),
-        });
-        self
+    builder_type_conversions!(DeleteVectors, DeleteVectorsBuilder);
+
+    #[derive(Clone, Default)]
+    pub struct DeletePointsBuilder {
+        points: Option<PointsSelector>,
+        shard_key_selector: Option<ShardKeySelector>,
     }
 
-    /// List of vector names to delete
-    pub fn vectors(&mut self, vectors: impl Into<VectorsSelector>) -> &mut Self {
-        self.vectors = Some(vectors.into());
-        self
-    }
+    impl DeletePointsBuilder {
+        pub fn new() -> Self {
+            Self {
+                points: None,
+                shard_key_selector: None,
+            }
+        }
 
-    /// Option for custom sharding to specify used shard keys
-    pub fn shard_key_selector(
-        &mut self,
-        shard_key_selector: impl Into<ShardKeySelector>,
-    ) -> &mut Self {
-        self.shard_key_selector = Some(shard_key_selector.into());
-        self
-    }
+        /// Affected points
+        pub fn points(
+            &mut self,
+            points: impl Into<points_selector::PointsSelectorOneOf>,
+        ) -> &mut Self {
+            self.points = Some(PointsSelector {
+                points_selector_one_of: Some(points.into()),
+            });
+            self
+        }
 
-    fn build_inner(&self) -> Result<DeleteVectors, ()> {
-        let builder = self.clone();
-        Ok(DeleteVectors {
-            points_selector: builder.points_selector,
-            vectors: builder.vectors,
-            shard_key_selector: builder.shard_key_selector,
-        })
-    }
-}
+        /// Option for custom sharding to specify used shard keys
+        pub fn shard_key_selector(
+            &mut self,
+            shard_key_selector: impl Into<ShardKeySelector>,
+        ) -> &mut Self {
+            self.shard_key_selector = Some(shard_key_selector.into());
+            self
+        }
 
-builder_type_conversions!(DeleteVectors, DeleteVectorsBuilder);
-
-#[derive(Clone, Default)]
-pub struct DeletePointsBuilder {
-    points: Option<PointsSelector>,
-    shard_key_selector: Option<ShardKeySelector>,
-}
-
-impl DeletePointsBuilder {
-    pub fn new() -> Self {
-        Self {
-            points: None,
-            shard_key_selector: None,
+        fn build_inner(&self) -> Result<DeletePoints, ()> {
+            let builder = self.clone();
+            Ok(DeletePoints {
+                points: builder.points,
+                shard_key_selector: builder.shard_key_selector,
+            })
         }
     }
 
-    /// Affected points
-    pub fn points(&mut self, points: impl Into<points_selector::PointsSelectorOneOf>) -> &mut Self {
-        self.points = Some(PointsSelector {
-            points_selector_one_of: Some(points.into()),
-        });
-        self
+    builder_type_conversions!(DeletePoints, DeletePointsBuilder);
+
+    #[derive(Clone, Default)]
+    pub struct ClearPayloadBuilder {
+        points: Option<PointsSelector>,
+        shard_key_selector: Option<ShardKeySelector>,
     }
 
-    /// Option for custom sharding to specify used shard keys
-    pub fn shard_key_selector(
-        &mut self,
-        shard_key_selector: impl Into<ShardKeySelector>,
-    ) -> &mut Self {
-        self.shard_key_selector = Some(shard_key_selector.into());
-        self
-    }
+    impl ClearPayloadBuilder {
+        pub fn new() -> Self {
+            Self {
+                points: None,
+                shard_key_selector: None,
+            }
+        }
 
-    fn build_inner(&self) -> Result<DeletePoints, ()> {
-        let builder = self.clone();
-        Ok(DeletePoints {
-            points: builder.points,
-            shard_key_selector: builder.shard_key_selector,
-        })
-    }
-}
+        /// Affected points
+        pub fn points(
+            &mut self,
+            points: impl Into<points_selector::PointsSelectorOneOf>,
+        ) -> &mut Self {
+            self.points = Some(PointsSelector {
+                points_selector_one_of: Some(points.into()),
+            });
+            self
+        }
 
-builder_type_conversions!(DeletePoints, DeletePointsBuilder);
+        /// Option for custom sharding to specify used shard keys
+        pub fn shard_key_selector(
+            &mut self,
+            shard_key_selector: impl Into<ShardKeySelector>,
+        ) -> &mut Self {
+            self.shard_key_selector = Some(shard_key_selector.into());
+            self
+        }
 
-#[derive(Clone, Default)]
-pub struct ClearPayloadBuilder {
-    points: Option<PointsSelector>,
-    shard_key_selector: Option<ShardKeySelector>,
-}
-
-impl ClearPayloadBuilder {
-    pub fn new() -> Self {
-        Self {
-            points: None,
-            shard_key_selector: None,
+        fn build_inner(&self) -> Result<ClearPayload, ()> {
+            let builder = self.clone();
+            Ok(ClearPayload {
+                points: builder.points,
+                shard_key_selector: builder.shard_key_selector,
+            })
         }
     }
 
-    /// Affected points
-    pub fn points(&mut self, points: impl Into<points_selector::PointsSelectorOneOf>) -> &mut Self {
-        self.points = Some(PointsSelector {
-            points_selector_one_of: Some(points.into()),
-        });
-        self
-    }
-
-    /// Option for custom sharding to specify used shard keys
-    pub fn shard_key_selector(
-        &mut self,
-        shard_key_selector: impl Into<ShardKeySelector>,
-    ) -> &mut Self {
-        self.shard_key_selector = Some(shard_key_selector.into());
-        self
-    }
-
-    fn build_inner(&self) -> Result<ClearPayload, ()> {
-        let builder = self.clone();
-        Ok(ClearPayload {
-            points: builder.points,
-            shard_key_selector: builder.shard_key_selector,
-        })
-    }
+    builder_type_conversions!(ClearPayload, ClearPayloadBuilder);
 }
-
-builder_type_conversions!(ClearPayload, ClearPayloadBuilder);
 
 #[derive(Builder)]
 #[builder(
@@ -409,5 +422,11 @@ impl SnapshotDownloadBuilder {
 
     pub fn build(self) -> SnapshotDownload {
         self.build_inner().unwrap()
+    }
+}
+
+impl From<SnapshotDownloadBuilder> for SnapshotDownload {
+    fn from(value: SnapshotDownloadBuilder) -> Self {
+        value.build()
     }
 }

--- a/src/qdrant_client/points.rs
+++ b/src/qdrant_client/points.rs
@@ -20,7 +20,10 @@ use crate::qdrant::{
 use crate::qdrant_client::{Qdrant, Result};
 
 impl Qdrant {
-    async fn with_points_client<T, O: Future<Output = std::result::Result<T, Status>>>(
+    pub(crate) async fn with_points_client<
+        T,
+        O: Future<Output = std::result::Result<T, Status>>,
+    >(
         &self,
         f: impl Fn(PointsClient<InterceptedService<Channel, TokenInterceptor>>) -> O,
     ) -> Result<T> {

--- a/src/qdrant_client/snapshot.rs
+++ b/src/qdrant_client/snapshot.rs
@@ -101,13 +101,10 @@ impl Qdrant {
     }
 
     #[cfg(feature = "download_snapshots")]
-    pub async fn download_snapshot<T>(
+    pub async fn download_snapshot(
         &self,
         options: impl Into<crate::qdrant::SnapshotDownload>,
-    ) -> Result<()>
-    where
-        T: ToString + Clone,
-    {
+    ) -> Result<()> {
         use crate::qdrant_client::errors::QdrantError;
         use futures_util::StreamExt;
         use std::io::Write;


### PR DESCRIPTION
- Add more api calls to the `create_collection_and_do_the_search` test
- Migrated the tests in lib.rs to the new client
- Added a few more conversions into service types to make working with the new client even smoother
- Fixes ambiguous builder types `DeletePointsBuilder` caused by the `use manual_builder::*` in qdrant.rs
- Remove unused generic type parameter in `download_snapshot`