### PR TITLE
Attempt to fix flaky test

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Formatter and linter
 
-on: [push]
+on: [ push ]
 
 jobs:
   lint:
@@ -9,11 +9,8 @@ jobs:
 
     steps:
       - name: Install minimal stable
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
       - uses: actions/checkout@v3
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,15 +16,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install minimal stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-    - uses: actions/checkout@v3
-    - name: Install dependencies
-      run: sudo apt-get install protobuf-compiler
-    - name: Login
-      run: cargo login ${{ secrets.CRATE_IO_API_TOKEN }}
-    - name: Publish
-      run: cargo publish
+      - name: Install minimal stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get install protobuf-compiler
+      - name: Login
+        run: cargo login ${{ secrets.CRATE_IO_API_TOKEN }}
+      - name: Publish
+        run: cargo publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo apt update; sudo apt upgrade -y;sudo apt-get install protobuf-compiler
+        run: sudo apt-get update; sudo apt-get upgrade -y; sudo apt-get install protobuf-compiler
       - name: Run integration tests
         run: |
           ./tests/integration-tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push]
+on: [ push ]
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
           toolchain: stable
       - uses: actions/checkout@v3
       - name: Install dependencies
-        run: sudo apt-get install protobuf-compiler
+        run: sudo apt update; sudo apt upgrade -y;sudo apt-get install protobuf-compiler
       - name: Run integration tests
         run: |
           ./tests/integration-tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install minimal stable
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-      - uses: actions/checkout@v3
+        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo apt update; sudo apt upgrade -y;sudo apt-get install protobuf-compiler
       - name: Run integration tests

--- a/tests/protos.rs
+++ b/tests/protos.rs
@@ -14,6 +14,7 @@ fn protos() {
     if !protos.any(|d| timestamp(d.unwrap().path()) > out_time)
         && timestamp("tests/protos.rs") <= out_time
     {
+        println!("protobuf files not changed. Exiting early!");
         return;
     }
 


### PR DESCRIPTION
Switches from archived `actions-rs/toolchain@v1` to `dtolnay/rust-toolchain@stable` as toolchain and upgrade packages before installing dependencies with apt.

There is also a further test run  [here](https://github.com/qdrant/rust-client/actions/runs/9127168467) in a separate branch, using those changes.