### PR TITLE
Deprecate NotA and provide alternatives

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -6,8 +6,9 @@ use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
 use std::marker::PhantomData;
 
-/// An error for failed conversions (e.g. calling `String::try_from(v)`
-/// on an integer [`Value`])
+/// An error for failed conversions (e.g. calling [`String::try_from(v)`](String::try_from) on an
+/// integer [`Value`])
+#[deprecated(since = "1.10.0", note = "new functions don't use this type anymore")]
 pub struct NotA<T> {
     marker: PhantomData<T>,
 }

--- a/src/grpc_conversions/extensions.rs
+++ b/src/grpc_conversions/extensions.rs
@@ -88,8 +88,8 @@ impl ScoredPoint {
 
 macro_rules! extract {
     ($kind:ident, $check:ident) => {
-        /// check if this value is a
-        #[doc = stringify!($kind)]
+        /// Check if this value is a
+        #[doc = stringify!([$kind])]
         pub fn $check(&self) -> bool {
             matches!(self.kind, Some($kind(_)))
         }
@@ -97,8 +97,11 @@ macro_rules! extract {
     ($kind:ident, $check:ident, $extract:ident, $ty:ty) => {
         extract!($kind, $check);
 
-        /// extract the contents if this value is a
-        #[doc = stringify!($kind)]
+        /// Get this value as
+        #[doc = stringify!([$ty])]
+        ///
+        /// Returns `None` if this value is not a
+        #[doc = stringify!([$kind].)]
         pub fn $extract(&self) -> Option<$ty> {
             if let Some($kind(v)) = self.kind {
                 Some(v)
@@ -110,8 +113,11 @@ macro_rules! extract {
     ($kind:ident, $check:ident, $extract:ident, ref $ty:ty) => {
         extract!($kind, $check);
 
-        /// extract the contents if this value is a
-        #[doc = stringify!($kind)]
+        /// Get this value as
+        #[doc = stringify!([$ty])]
+        ///
+        /// Returns `None` if this value is not a
+        #[doc = stringify!([$kind].)]
         pub fn $extract(&self) -> Option<&$ty> {
             if let Some($kind(v)) = &self.kind {
                 Some(v)
@@ -140,7 +146,7 @@ mod value_extract_impl {
 
 impl Value {
     #[cfg(feature = "serde")]
-    /// convert this into a `serde_json::Value`
+    /// Convert this into a [`serde_json::Value`]
     ///
     /// # Examples:
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,11 +123,10 @@ pub mod client;
 )]
 pub mod config;
 /// Deprecated error type
-// TODO: deprecate once NotA is removed/deprecated
-// #[deprecated(
-//     since = "1.10.0",
-//     note = "use new error type at `qdrant_client::Error` instead"
-// )]
+#[deprecated(
+    since = "1.10.0",
+    note = "use new error type at `qdrant_client::Error` instead"
+)]
 pub mod error;
 /// Deprecated prelude
 #[deprecated(since = "1.10.0", note = "use types directly")]


### PR DESCRIPTION
Deprecate the `NotA` type which was rather confusing.

This provides better alternatives for functions that were using this.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?