### PR TITLE
Expose Payload at root, hide obsolete modules, vendor some types along in qdrant module

### DIFF
--- a/examples/search.rs
+++ b/examples/search.rs
@@ -1,10 +1,9 @@
-use qdrant_client::payload::Payload;
 use qdrant_client::qdrant::{
     Condition, CreateCollectionBuilder, Distance, Filter, PointStruct, QuantizationType,
     ScalarQuantizationBuilder, SearchParamsBuilder, SearchPointsBuilder, UpsertPointsBuilder,
     VectorParamsBuilder,
 };
-use qdrant_client::{Qdrant, Result};
+use qdrant_client::{Payload, Qdrant, Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/src/builder_ext.rs
+++ b/src/builder_ext.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use crate::builder_types::RecommendExample;
 use crate::qdrant::{
     shard_key, BinaryQuantizationBuilder, ClearPayloadPointsBuilder, ContextExamplePair,
     CountPointsBuilder, CreateAliasBuilder, CreateCollectionBuilder,
@@ -10,7 +9,7 @@ use crate::qdrant::{
     DiscoverPoints, DiscoverPointsBuilder, Distance, GetPointsBuilder, LookupLocationBuilder,
     OrderByBuilder, PayloadExcludeSelector, PayloadIncludeSelector, PointId, PointStruct,
     PointVectors, PointsUpdateOperation, ProductQuantizationBuilder, QuantizationType,
-    QueryPointsBuilder, RecommendBatchPointsBuilder, RecommendPointGroups,
+    QueryPointsBuilder, RecommendBatchPointsBuilder, RecommendExample, RecommendPointGroups,
     RecommendPointGroupsBuilder, RecommendPoints, RecommendPointsBuilder, RenameAliasBuilder,
     ScalarQuantizationBuilder, ScrollPointsBuilder, SearchBatchPointsBuilder,
     SearchPointGroupsBuilder, SearchPoints, SearchPointsBuilder, SetPayloadPointsBuilder, ShardKey,

--- a/src/builder_types.rs
+++ b/src/builder_types.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::{PointId, Vector};
 
+/// A recommendation example, being a [`PointId`] or a [`Vector`]
 pub enum RecommendExample {
     PointId(PointId),
     Vector(Vector),

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -244,8 +244,7 @@ impl qdrant::Condition {
     /// # Examples:
     ///
     /// ```
-    /// use qdrant_client::qdrant::DatetimeRange;
-    /// use qdrant_client::Timestamp;
+    /// use qdrant_client::qdrant::{DatetimeRange, Timestamp};
     /// qdrant_client::qdrant::Condition::datetime_range("timestamp", DatetimeRange {
     ///     gte: Some(Timestamp::date(2023, 2, 8).unwrap()),
     ///     ..Default::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@
 // Public modules
 pub mod auth;
 pub mod builder_types;
-pub mod payload;
 
 // Generated Qdrant API types
 /// API types
@@ -105,6 +104,7 @@ mod filters;
 mod grpc_conversions;
 mod grpc_macros;
 mod manual_builder;
+mod payload;
 mod qdrant_client;
 
 // Deprecated modules
@@ -135,6 +135,7 @@ pub mod prelude;
 pub mod serde;
 
 // Re-exports
+pub use crate::payload::Payload;
 pub use crate::qdrant_client::{config::QdrantConfig, error::Error, Qdrant, QdrantBuilder, Result};
 
 // Vendored re-exports

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! The Qdrant Vector Database client
+//! The [Qdrant](https://qdrant.tech/) Vector Search client
 //!
 //! This library uses GRPC to connect to the Qdrant server and allows you to
 //! access most if not all features. If you find a missing feature, please open
@@ -34,10 +34,11 @@
 //!# Ok(())
 //!# }
 //! ```
-//! The most interesting parts are the two arguments of `VectorParamsBuilder::new`.
-//! The first one (`512`) is the length of vectors to store and the second one (`Distance::Cosine`)
-//! is the Distance, which is the [`Distance`](qdrant::Distance) measure to gauge
-//! similarity for the nearest neighbors search.
+//! The most interesting parts are the two arguments of
+//! [`VectorParamsBuilder::new`](qdrant::VectorParamsBuilder::new). The first one (`512`) is the
+//! length of vectors to store and the second one ([`Distance::Cosine`](qdrant::Distance::Cosine))
+//! is the Distance, which is the [`Distance`](qdrant::Distance) measure to gauge similarity for
+//! the nearest neighbors search.
 //!
 //! Now we have a collection, we can insert (or rather upsert) points.
 //! Points have an id, one or more vectors and a payload.
@@ -80,12 +81,13 @@
 //!# Ok(())
 //!# }
 //! ```
-//! The parameter for `SearchPointsBuilder::new()` contsructor are pretty straightforward:
-//! Name of the collection, the vector and how many top-k results to return.
-//! The `with_payload(true)` call tells qdrant to also return the (full) payload data for each point.
-//! You can also add a `.filter()` call to the
-//! [`SearchPointsBuilder`](qdrant::SearchPointsBuilder) to filter the result.
-//! See the [`Filter`](qdrant::Filter) documentation for details.
+//! The parameter for [`SearchPointsBuilder::new()`](qdrant::SearchPointsBuilder::new) contsructor
+//! are pretty straightforward: name of the collection, the vector and how many top-k results to
+//! return. The [`with_payload(true)`](qdrant::SearchPointsBuilder::with_payload) call tells qdrant
+//! to also return the (full) payload data for each point. You can also add a
+//! [`filter()`](qdrant::SearchPointsBuilder::filter) call to the
+//! [`SearchPointsBuilder`](qdrant::SearchPointsBuilder) to filter the result. See the
+//! [`Filter`](qdrant::Filter) documentation for details.
 
 // Generated Qdrant API types
 /// API types

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,9 +87,6 @@
 //! [`SearchPointsBuilder`](qdrant::SearchPointsBuilder) to filter the result.
 //! See the [`Filter`](qdrant::Filter) documentation for details.
 
-// Public modules
-pub mod auth;
-
 // Generated Qdrant API types
 /// API types
 #[allow(clippy::all)]
@@ -97,6 +94,7 @@ pub mod auth;
 pub mod qdrant;
 
 // Internal modules
+mod auth;
 mod builder_ext;
 mod builder_types;
 mod channel_pool;
@@ -137,10 +135,6 @@ pub mod serde;
 // Re-exports
 pub use crate::payload::Payload;
 pub use crate::qdrant_client::{config::QdrantConfig, error::Error, Qdrant, QdrantBuilder, Result};
-
-// Vendored re-exports
-#[doc(no_inline)]
-pub use prost_types::Timestamp;
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,6 @@
 
 // Public modules
 pub mod auth;
-pub mod builder_types;
 
 // Generated Qdrant API types
 /// API types
@@ -99,6 +98,7 @@ pub mod qdrant;
 
 // Internal modules
 mod builder_ext;
+mod builder_types;
 mod channel_pool;
 mod filters;
 mod grpc_conversions;

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -3,15 +3,33 @@ use crate::qdrant::Value;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Point payload
+///
+/// A JSON-like object that can be attached to points. With payloads you can store any kind of
+/// information along with your points. Qdrant provides comprehensive ways to filter on payload
+/// values during vector search.
+///
+/// Payload documentation: <https://qdrant.tech/documentation/concepts/payload/>
 #[derive(Clone, PartialEq, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Payload(pub(crate) HashMap<String, Value>);
 
-#[cfg(feature = "serde")]
 impl Payload {
-    /// Convert a JSON object into a Payload
+    /// Construct a new empty payload object
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    /// Construct a payload object from the given hash map
+    #[deprecated(since = "1.10.0", note = "use `Payload::from` instead")]
+    pub fn new_from_hashmap(payload: HashMap<String, Value>) -> Self {
+        Self(payload)
+    }
+
+    /// Convert a JSON object into payload
     ///
     /// Returns `None` if the given JSON value is not an object.
+    #[cfg(feature = "serde")]
     #[inline]
     pub fn from_json_object(value: serde_json::Value) -> Option<Self> {
         if let serde_json::Value::Object(object) = value {
@@ -20,12 +38,17 @@ impl Payload {
             None
         }
     }
+
+    /// Insert a payload value at the given key, replacing any existing value
+    pub fn insert(&mut self, key: impl ToString, val: impl Into<Value>) {
+        self.0.insert(key.to_string(), val.into());
+    }
 }
 
-impl From<Payload> for HashMap<String, Value> {
+impl From<HashMap<String, Value>> for Payload {
     #[inline]
-    fn from(payload: Payload) -> Self {
-        payload.0
+    fn from(payload: HashMap<String, Value>) -> Self {
+        Self(payload)
     }
 }
 
@@ -41,11 +64,22 @@ impl From<HashMap<&str, Value>> for Payload {
     }
 }
 
+impl From<Payload> for HashMap<String, Value> {
+    #[inline]
+    fn from(payload: Payload) -> Self {
+        payload.0
+    }
+}
+
 #[cfg(feature = "serde")]
 impl From<serde_json::Map<String, serde_json::Value>> for Payload {
     #[inline]
     fn from(obj: serde_json::Map<String, serde_json::Value>) -> Self {
-        Payload::new_from_hashmap(obj.into_iter().map(|(k, v)| (k, v.into())).collect())
+        Payload::from(
+            obj.into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect::<HashMap<String, Value>>(),
+        )
     }
 }
 
@@ -59,20 +93,6 @@ where
             map.insert(k.into(), v);
         }
         Self(map)
-    }
-}
-
-impl Payload {
-    pub fn new() -> Self {
-        Self(HashMap::new())
-    }
-
-    pub fn new_from_hashmap(payload: HashMap<String, Value>) -> Self {
-        Self(payload)
-    }
-
-    pub fn insert(&mut self, key: impl ToString, val: impl Into<Value>) {
-        self.0.insert(key.to_string(), val.into());
     }
 }
 

--- a/src/qdrant.rs
+++ b/src/qdrant.rs
@@ -8706,3 +8706,4 @@ builder_type_conversions!(DeletePoints, DeletePointsBuilder, true);
 
 pub use crate::manual_builder::*;
 pub use crate::builder_types::*;
+pub use prost_types::Timestamp;

--- a/src/qdrant.rs
+++ b/src/qdrant.rs
@@ -8705,3 +8705,4 @@ builder_type_conversions!(RenameAlias, RenameAliasBuilder, true);
 builder_type_conversions!(DeletePoints, DeletePointsBuilder, true);
 
 pub use crate::manual_builder::*;
+pub use crate::builder_types::*;

--- a/tests/protos.rs
+++ b/tests/protos.rs
@@ -37,6 +37,7 @@ fn protos() {
 
     // import our manual builder here so all builder come from the same module in the end user API.
     append_to_file(GRPC_OUTPUT_FILE, "pub use crate::manual_builder::*;");
+    append_to_file(GRPC_OUTPUT_FILE, "pub use crate::builder_types::*;");
 
     panic!("proto definitions changed. Stubs recompiled. Please commit the changes.")
 }

--- a/tests/protos.rs
+++ b/tests/protos.rs
@@ -39,6 +39,9 @@ fn protos() {
     append_to_file(GRPC_OUTPUT_FILE, "pub use crate::manual_builder::*;");
     append_to_file(GRPC_OUTPUT_FILE, "pub use crate::builder_types::*;");
 
+    // Vendor gRPC types used in our objects
+    append_to_file(GRPC_OUTPUT_FILE, "pub use prost_types::Timestamp;");
+
     panic!("proto definitions changed. Stubs recompiled. Please commit the changes.")
 }
 


### PR DESCRIPTION
This does a few things:
- expose `Payload` at the root level (maybe we don't want this, but it feels like a fine candidate to me)
- vendor `RecommendExample` and `Timestamp` in the `qdrant` module, that just makes more sense for endusers
- hide some more obsolete modules
- improve documentation

We're now left with:

![image](https://github.com/qdrant/rust-client/assets/856222/791a3608-b855-4e5d-99ee-f14a55bd2a7b)


### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?