### PR TITLE
Add documentation to operation/endpoint methods

### DIFF
--- a/src/client/collection.rs
+++ b/src/client/collection.rs
@@ -337,6 +337,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::create_shard_key` instead"
+    )]
     pub async fn create_shard_key(
         &self,
         collection_name: impl AsRef<str>,
@@ -366,6 +370,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::create_shard_key` instead"
+    )]
     pub async fn delete_shard_key(
         &self,
         collection_name: impl AsRef<str>,

--- a/src/client/collection.rs
+++ b/src/client/collection.rs
@@ -45,6 +45,10 @@ impl QdrantClient {
             .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::list_collections` instead"
+    )]
     pub async fn list_collections(&self) -> anyhow::Result<ListCollectionsResponse> {
         Ok(self
             .with_collections_client(|mut collection_api| async move {
@@ -54,7 +58,10 @@ impl QdrantClient {
             .await?)
     }
 
-    #[deprecated(since = "1.8.0", note = "Please use `collection_exists` instead")]
+    #[deprecated(
+        since = "1.8.0",
+        note = "use new `qdrant_client::Qdrant::collection_exists` instead"
+    )]
     pub async fn has_collection(&self, collection_name: impl ToString) -> anyhow::Result<bool> {
         let collection_name = collection_name.to_string();
         let response = self.list_collections().await?;
@@ -66,6 +73,10 @@ impl QdrantClient {
         Ok(result)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::collection_exists` instead"
+    )]
     pub async fn collection_exists(&self, collection_name: impl ToString) -> anyhow::Result<bool> {
         let collection_name_ref = &collection_name.to_string();
         Ok(self
@@ -83,6 +94,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::create_collection` instead"
+    )]
     pub async fn create_collection(
         &self,
         details: &CreateCollection,
@@ -96,6 +111,10 @@ impl QdrantClient {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::update_collection` instead"
+    )]
     pub async fn update_collection(
         &self,
         collection_name: impl ToString,
@@ -129,6 +148,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_collection` instead"
+    )]
     pub async fn delete_collection(
         &self,
         collection_name: impl ToString,
@@ -149,6 +172,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::collection_info` instead"
+    )]
     pub async fn collection_info(
         &self,
         collection_name: impl ToString,
@@ -168,6 +195,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::create_alias` instead"
+    )]
     pub async fn create_alias(
         &self,
         collection_name: impl ToString,
@@ -186,6 +217,10 @@ impl QdrantClient {
         self.update_aliases(change_aliases).await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_alias` instead"
+    )]
     pub async fn delete_alias(
         &self,
         alias_name: impl ToString,
@@ -202,6 +237,10 @@ impl QdrantClient {
         self.update_aliases(change_aliases).await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::rename_alias` instead"
+    )]
     pub async fn rename_alias(
         &self,
         old_alias_name: impl ToString,
@@ -221,6 +260,10 @@ impl QdrantClient {
     }
 
     // lower level API
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::create_alias`, `qdrant_client::Qdrant::rename_alias` or `qdrant_client::Qdrant::delete_alias` instead"
+    )]
     pub async fn update_aliases(
         &self,
         change_aliases: ChangeAliases,
@@ -237,6 +280,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::list_collection_aliases` instead"
+    )]
     pub async fn list_collection_aliases(
         &self,
         collection_name: impl ToString,
@@ -255,6 +302,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::list_aliases` instead"
+    )]
     pub async fn list_aliases(&self) -> anyhow::Result<ListAliasesResponse> {
         Ok(self
             .with_collections_client(|mut collection_api| async move {
@@ -264,6 +315,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::collection_cluster_info` instead"
+    )]
     pub async fn collection_cluster_info(
         &self,
         collection_name: impl ToString,
@@ -334,6 +389,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::update_collection_cluster_setup` instead"
+    )]
     pub async fn update_collection_cluster_setup(
         &self,
         collection_name: impl ToString,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -21,6 +21,17 @@ use crate::qdrant::{qdrant_client, HealthCheckReply, HealthCheckRequest};
 #[deprecated(since = "1.10.0", note = "use `qdrant_client::QdrantBuilder` instead")]
 pub type QdrantClientBuilder = QdrantClientConfig;
 
+/// Deprecated Qdrant client
+///
+/// # Deprecated
+///
+/// This client is deprecated.
+///
+/// Please switch to the new [`Qdrant`](crate::Qdrant) client. It is easier to use and provides a
+/// more robust interface.
+///
+/// See examples at the [crate root](crate) or at each individual [`Qdrant`](crate::Qdrant)
+/// operation.
 #[deprecated(since = "1.10.0", note = "use `qdrant_client::Qdrant` instead")]
 pub struct QdrantClient {
     pub channel: ChannelPool,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -40,10 +40,18 @@ pub struct QdrantClient {
 
 impl QdrantClient {
     /// Create a builder to setup the client
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::from_url` instead"
+    )]
     pub fn from_url(url: &str) -> QdrantClientBuilder {
         QdrantClientBuilder::from_url(url)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::new` instead"
+    )]
     pub fn new(cfg: Option<QdrantClientConfig>) -> Result<Self> {
         let cfg = cfg.unwrap_or_default();
 
@@ -88,6 +96,10 @@ impl QdrantClient {
             .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::health_check` instead"
+    )]
     pub async fn health_check(&self) -> Result<HealthCheckReply> {
         Ok(self
             .with_root_qdrant_client(|mut qdrant_api| async move {

--- a/src/client/points.rs
+++ b/src/client/points.rs
@@ -45,6 +45,10 @@ impl QdrantClient {
             .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::update_points_batch` instead"
+    )]
     async fn _batch_updates(
         &self,
         collection_name: impl ToString,
@@ -70,6 +74,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::update_points_batch` instead"
+    )]
     pub async fn batch_updates(
         &self,
         collection_name: impl ToString,
@@ -80,6 +88,10 @@ impl QdrantClient {
             .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::update_points_batch` instead"
+    )]
     pub async fn batch_updates_blocking(
         &self,
         collection_name: impl ToString,
@@ -96,6 +108,10 @@ impl QdrantClient {
     /// [`upsert_points_blocking`](Self::upsert_points_blocking) for that.
     /// Also this method does not split the points to insert to avoid timeouts,
     /// look at [`upsert_points_batch`](Self::upsert_points_batch) for that.
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::upsert_points` instead"
+    )]
     pub async fn upsert_points(
         &self,
         collection_name: impl ToString,
@@ -117,6 +133,10 @@ impl QdrantClient {
     /// If points with given ID already exist, they will be overwritten.
     /// This method does not split the points to insert to avoid timeouts,
     /// look at [`upsert_points_batch`](Self::upsert_points_batch) for that.
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::upsert_points` instead"
+    )]
     pub async fn upsert_points_blocking(
         &self,
         collection_name: impl ToString,
@@ -129,6 +149,10 @@ impl QdrantClient {
     }
 
     #[inline]
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::upsert_points` instead"
+    )]
     async fn _upsert_points(
         &self,
         collection_name: impl ToString,
@@ -162,6 +186,10 @@ impl QdrantClient {
     /// If points with given ID already exist, they will be overwritten.
     /// This method does *not* wait for completion of the operation, use
     /// [`upsert_points_batch_blocking`](Self::upsert_points_batch_blocking) for that.
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::upsert_points_batch` instead"
+    )]
     pub async fn upsert_points_batch(
         &self,
         collection_name: impl ToString,
@@ -184,6 +212,10 @@ impl QdrantClient {
     /// Insert or update points into the collection, splitting in chunks and
     /// waiting for completion of each.
     /// If points with given ID already exist, they will be overwritten.
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::upsert_points_batch` instead"
+    )]
     pub async fn upsert_points_batch_blocking(
         &self,
         collection_name: impl ToString,
@@ -204,6 +236,10 @@ impl QdrantClient {
     }
 
     #[inline]
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::upsert_points_batch` instead"
+    )]
     async fn _upsert_points_batch(
         &self,
         collection_name: impl ToString,
@@ -248,6 +284,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::set_payload` instead"
+    )]
     pub async fn set_payload(
         &self,
         collection_name: impl ToString,
@@ -269,6 +309,10 @@ impl QdrantClient {
         .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::set_payload` instead"
+    )]
     pub async fn set_payload_blocking(
         &self,
         collection_name: impl ToString,
@@ -292,6 +336,10 @@ impl QdrantClient {
 
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::set_payload` instead"
+    )]
     async fn _set_payload(
         &self,
         collection_name: impl ToString,
@@ -327,6 +375,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::overwrite_payload` instead"
+    )]
     pub async fn overwrite_payload(
         &self,
         collection_name: impl ToString,
@@ -348,6 +400,10 @@ impl QdrantClient {
         .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::overwrite_payload` instead"
+    )]
     pub async fn overwrite_payload_blocking(
         &self,
         collection_name: impl ToString,
@@ -371,6 +427,10 @@ impl QdrantClient {
 
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::overwrite_payload` instead"
+    )]
     async fn _overwrite_payload(
         &self,
         collection_name: impl ToString,
@@ -406,6 +466,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_payload` instead"
+    )]
     pub async fn delete_payload(
         &self,
         collection_name: impl ToString,
@@ -425,6 +489,10 @@ impl QdrantClient {
         .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_payload` instead"
+    )]
     pub async fn delete_payload_blocking(
         &self,
         collection_name: impl ToString,
@@ -445,6 +513,10 @@ impl QdrantClient {
     }
 
     #[inline]
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_payload` instead"
+    )]
     async fn _delete_payload(
         &self,
         collection_name: impl ToString,
@@ -477,6 +549,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::clear_payload` instead"
+    )]
     pub async fn clear_payload(
         &self,
         collection_name: impl ToString,
@@ -494,6 +570,10 @@ impl QdrantClient {
         .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::clear_payload` instead"
+    )]
     pub async fn clear_payload_blocking(
         &self,
         collection_name: impl ToString,
@@ -512,6 +592,10 @@ impl QdrantClient {
     }
 
     #[inline]
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::clear_payload` instead"
+    )]
     async fn _clear_payload(
         &self,
         collection_name: impl ToString,
@@ -542,6 +626,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::get_points` instead"
+    )]
     pub async fn get_points(
         &self,
         collection_name: impl ToString,
@@ -582,6 +670,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::search_points` instead"
+    )]
     pub async fn search_points(&self, request: &SearchPoints) -> anyhow::Result<SearchResponse> {
         Ok(self
             .with_points_client(|mut points_api| async move {
@@ -591,6 +683,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::search_batch_points` instead"
+    )]
     pub async fn search_batch_points(
         &self,
         request: &SearchBatchPoints,
@@ -603,6 +699,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::search_groups` instead"
+    )]
     pub async fn search_groups(
         &self,
         request: &SearchPointGroups,
@@ -615,6 +715,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_points` instead"
+    )]
     pub async fn delete_points(
         &self,
         collection_name: impl ToString,
@@ -626,6 +730,10 @@ impl QdrantClient {
             .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_points` instead"
+    )]
     pub async fn delete_points_blocking(
         &self,
         collection_name: impl ToString,
@@ -637,6 +745,10 @@ impl QdrantClient {
             .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_points` instead"
+    )]
     async fn _delete_points(
         &self,
         collection_name: impl ToString,
@@ -667,6 +779,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_vectors` instead"
+    )]
     pub async fn delete_vectors(
         &self,
         collection_name: impl ToString,
@@ -686,6 +802,10 @@ impl QdrantClient {
         .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_vectors` instead"
+    )]
     pub async fn delete_vectors_blocking(
         &self,
         collection_name: impl ToString,
@@ -705,6 +825,10 @@ impl QdrantClient {
         .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_vectors` instead"
+    )]
     async fn _delete_vectors(
         &self,
         collection_name: impl ToString,
@@ -737,6 +861,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::update_vectors` instead"
+    )]
     pub async fn update_vectors(
         &self,
         collection_name: impl ToString,
@@ -748,6 +876,10 @@ impl QdrantClient {
             .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::update_vectors` instead"
+    )]
     pub async fn update_vectors_blocking(
         &self,
         collection_name: impl ToString,
@@ -759,6 +891,10 @@ impl QdrantClient {
             .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::update_vectors` instead"
+    )]
     async fn _update_vectors(
         &self,
         collection_name: impl ToString,
@@ -789,6 +925,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::scroll` instead"
+    )]
     pub async fn scroll(&self, request: &ScrollPoints) -> anyhow::Result<ScrollResponse> {
         Ok(self
             .with_points_client(|mut points_api| async move {
@@ -798,6 +938,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::recommend` instead"
+    )]
     pub async fn recommend(&self, request: &RecommendPoints) -> anyhow::Result<RecommendResponse> {
         Ok(self
             .with_points_client(|mut points_api| async move {
@@ -807,6 +951,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::recommend_batch` instead"
+    )]
     pub async fn recommend_batch(
         &self,
         request: &RecommendBatchPoints,
@@ -819,6 +967,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::recommend_groups` instead"
+    )]
     pub async fn recommend_groups(
         &self,
         request: &RecommendPointGroups,
@@ -831,6 +983,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::discover` instead"
+    )]
     pub async fn discover(&self, request: &DiscoverPoints) -> anyhow::Result<DiscoverResponse> {
         Ok(self
             .with_points_client(|mut points_api| async move {
@@ -840,6 +996,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::discover_batch` instead"
+    )]
     pub async fn discover_batch(
         &self,
         request: &DiscoverBatchPoints,
@@ -852,6 +1012,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::count` instead"
+    )]
     pub async fn count(&self, request: &CountPoints) -> anyhow::Result<CountResponse> {
         Ok(self
             .with_points_client(|mut points_api| async move {
@@ -864,6 +1028,10 @@ impl QdrantClient {
     /// Perform multiple point, vector and payload insert, update and delete operations in one request.
     /// This method does *not* wait for completion of the operation, use
     /// [`update_batch_points_blocking`](Self::update_batch_points_blocking) for that.
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::update_points_batch` instead"
+    )]
     pub async fn update_batch_points(
         &self,
         collection_name: impl ToString,
@@ -876,6 +1044,10 @@ impl QdrantClient {
 
     /// Perform multiple point, vector and payload insert, update and delete operations in one request.
     /// This method waits for completion on each operation.
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::update_points_batch` instead"
+    )]
     pub async fn update_batch_points_blocking(
         &self,
         collection_name: impl ToString,
@@ -886,6 +1058,10 @@ impl QdrantClient {
             .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::update_points_batch` instead"
+    )]
     async fn _update_batch_points(
         &self,
         collection_name: impl ToString,
@@ -913,6 +1089,10 @@ impl QdrantClient {
     }
 
     /// Create index for a payload field
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::create_field_index` instead"
+    )]
     pub async fn _create_field_index(
         &self,
         collection_name: impl ToString,
@@ -945,6 +1125,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::create_field_index` instead"
+    )]
     pub async fn create_field_index(
         &self,
         collection_name: impl ToString,
@@ -964,6 +1148,10 @@ impl QdrantClient {
         .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::create_field_index` instead"
+    )]
     pub async fn create_field_index_blocking(
         &self,
         collection_name: impl ToString,
@@ -983,6 +1171,10 @@ impl QdrantClient {
         .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_field_index` instead"
+    )]
     pub async fn _delete_field_index(
         &self,
         collection_name: impl ToString,
@@ -1011,6 +1203,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_field_index` instead"
+    )]
     pub async fn delete_field_index(
         &self,
         collection_name: impl ToString,
@@ -1021,6 +1217,10 @@ impl QdrantClient {
             .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_field_index` instead"
+    )]
     pub async fn delete_field_index_blocking(
         &self,
         collection_name: impl ToString,

--- a/src/client/points.rs
+++ b/src/client/points.rs
@@ -90,7 +90,7 @@ impl QdrantClient {
             .await
     }
 
-    /// Update or insert points into the collection.
+    /// Insert or update points into the collection.
     /// If points with given ID already exist, they will be overwritten.
     /// This method does *not* wait for completion of the operation, use
     /// [`upsert_points_blocking`](Self::upsert_points_blocking) for that.
@@ -113,7 +113,7 @@ impl QdrantClient {
         .await
     }
 
-    /// Update or insert points into the collection, wait for completion.
+    /// Insert or update points into the collection, wait for completion.
     /// If points with given ID already exist, they will be overwritten.
     /// This method does not split the points to insert to avoid timeouts,
     /// look at [`upsert_points_batch`](Self::upsert_points_batch) for that.
@@ -158,7 +158,7 @@ impl QdrantClient {
             .await?)
     }
 
-    /// Update or insert points into the collection, splitting in chunks.
+    /// Insert or update points into the collection, splitting in chunks.
     /// If points with given ID already exist, they will be overwritten.
     /// This method does *not* wait for completion of the operation, use
     /// [`upsert_points_batch_blocking`](Self::upsert_points_batch_blocking) for that.
@@ -181,7 +181,7 @@ impl QdrantClient {
         .await
     }
 
-    /// Update or insert points into the collection, splitting in chunks and
+    /// Insert or update points into the collection, splitting in chunks and
     /// waiting for completion of each.
     /// If points with given ID already exist, they will be overwritten.
     pub async fn upsert_points_batch_blocking(

--- a/src/client/snapshot.rs
+++ b/src/client/snapshot.rs
@@ -38,6 +38,10 @@ impl QdrantClient {
             .await
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::create_snapshot` instead"
+    )]
     pub async fn create_snapshot(
         &self,
         collection_name: impl ToString,
@@ -57,6 +61,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::list_snapshot` instead"
+    )]
     pub async fn list_snapshots(
         &self,
         collection_name: impl ToString,
@@ -75,6 +83,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_snapshot` instead"
+    )]
     pub async fn delete_snapshot(
         &self,
         collection_name: impl ToString,
@@ -97,6 +109,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::create_full_snapshot` instead"
+    )]
     pub async fn create_full_snapshot(&self) -> anyhow::Result<CreateSnapshotResponse> {
         Ok(self
             .with_snapshot_client(|mut client| async move {
@@ -107,6 +123,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::list_full_snapshots` instead"
+    )]
     pub async fn list_full_snapshots(&self) -> anyhow::Result<ListSnapshotsResponse> {
         Ok(self
             .with_snapshot_client(|mut client| async move {
@@ -116,6 +136,10 @@ impl QdrantClient {
             .await?)
     }
 
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::delete_full_snapshot` instead"
+    )]
     pub async fn delete_full_snapshot(
         &self,
         snapshot_name: impl ToString,
@@ -135,6 +159,10 @@ impl QdrantClient {
     }
 
     #[cfg(feature = "download_snapshots")]
+    #[deprecated(
+        since = "1.10.0",
+        note = "use new `qdrant_client::Qdrant::download_snapshot` instead"
+    )]
     pub async fn download_snapshot<T>(
         &self,
         out_path: impl Into<PathBuf>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,9 @@
 //!
 //! Documentation: <https://qdrant.tech/documentation/concepts/search/>
 
+#![doc(html_logo_url = "https://qdrant.tech/favicon/android-chrome-192x192.png")]
+#![doc(issue_tracker_base_url = "https://github.com/qdrant/rust-client/issues/")]
+
 // Generated Qdrant API types
 /// API types
 #[allow(clippy::all)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,25 +141,30 @@ mod qdrant_client;
     since = "1.10.0",
     note = "use new client at `qdrant_client::Qdrant` instead"
 )]
+#[doc(hidden)]
 pub mod client;
 /// Deprecated Qdrant client config
 #[deprecated(
     since = "1.10.0",
     note = "use new config at `qdrant_client::QdrantConfig` instead"
 )]
+#[doc(hidden)]
 pub mod config;
 /// Deprecated error type
 #[deprecated(
     since = "1.10.0",
     note = "use new error type at `qdrant_client::Error` instead"
 )]
+#[doc(hidden)]
 pub mod error;
 /// Deprecated prelude
 #[deprecated(since = "1.10.0", note = "use types directly")]
+#[doc(hidden)]
 pub mod prelude;
 /// Deprecated serde helper
 #[cfg(feature = "serde")]
 #[deprecated(since = "1.10.0", note = "use `Payload::from_json_object` instead")]
+#[doc(hidden)]
 pub mod serde;
 
 // Re-exports

--- a/src/qdrant_client/collection.rs
+++ b/src/qdrant_client/collection.rs
@@ -17,8 +17,14 @@ use crate::qdrant::{
 };
 use crate::qdrant_client::{Qdrant, QdrantResult};
 
+/// Collection operations.
+///
+/// Create, update and delete collections, manage collection aliases and collection cluster
+/// configuration.
+///
+/// Documentation: <https://qdrant.tech/documentation/concepts/collections/>
 impl Qdrant {
-    pub(crate) async fn with_collections_client<T, O: Future<Output = Result<T, Status>>>(
+    pub(super) async fn with_collections_client<T, O: Future<Output = Result<T, Status>>>(
         &self,
         f: impl Fn(CollectionsClient<InterceptedService<Channel, TokenInterceptor>>) -> O,
     ) -> QdrantResult<T> {
@@ -42,6 +48,18 @@ impl Qdrant {
         Ok(result)
     }
 
+    /// Delete an existing collection.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    ///# async fn delete_collection(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client.delete_collection("my_collection").await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/collections/#delete-collection>
     pub async fn delete_collection(
         &self,
         request: impl Into<DeleteCollection>,
@@ -55,6 +73,25 @@ impl Qdrant {
         .await
     }
 
+    /// Create a new collection.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{CreateCollectionBuilder, Distance, VectorParamsBuilder};
+    ///
+    ///# async fn create_collection(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .create_collection(
+    ///         CreateCollectionBuilder::new("my_collection")
+    ///             .vectors_config(VectorParamsBuilder::new(100, Distance::Cosine)),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/collections/#create-a-collection>
     pub async fn create_collection(
         &self,
         request: impl Into<CreateCollection>,
@@ -68,6 +105,21 @@ impl Qdrant {
         .await
     }
 
+    /// List all collections.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    ///# async fn list_collections(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client.list_collections().await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// This only lists collection names. To list collection name aliases, use
+    /// [`list_aliases`](Self::list_aliases).
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/collections/#list-all-collections>
     pub async fn list_collections(&self) -> QdrantResult<ListCollectionsResponse> {
         self.with_collections_client(|mut collection_api| async move {
             let result = collection_api.list(ListCollectionsRequest {}).await?;
@@ -76,6 +128,18 @@ impl Qdrant {
         .await
     }
 
+    /// Check whether a collection exists.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    ///# async fn collection_exists(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client.collection_exists("my_collection").await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/collections/#check-collection-existence>
     pub async fn collection_exists(
         &self,
         request: impl Into<CollectionExistsRequest>,
@@ -92,6 +156,29 @@ impl Qdrant {
         .await
     }
 
+    /// Update collection.
+    ///
+    /// Change parameters of a collection, such as the indexing threshold, for a collection that
+    /// has already been created.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{OptimizersConfigDiffBuilder, UpdateCollectionBuilder};
+    ///
+    ///# async fn create_collection(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .update_collection(
+    ///         UpdateCollectionBuilder::new("my_collection").optimizers_config(
+    ///             OptimizersConfigDiffBuilder::default().indexing_threshold(10_000),
+    ///         ),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/collections/#update-collection-parameters>
     pub async fn update_collection(
         &self,
         request: impl Into<UpdateCollection>,
@@ -105,6 +192,18 @@ impl Qdrant {
         .await
     }
 
+    /// Get collection info.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    ///# async fn collection_info(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client.collection_info("my_collection").await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/collections/#collection-info>
     pub async fn collection_info(
         &self,
         request: impl Into<GetCollectionInfoRequest>,
@@ -117,6 +216,22 @@ impl Qdrant {
         .await
     }
 
+    /// Create new collection name alias.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::CreateAliasBuilder;
+    ///
+    ///# async fn create_alias(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .create_alias(CreateAliasBuilder::new("my_collection", "my_alias"))
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/collections/#create-alias>
     pub async fn create_alias(
         &self,
         request: impl Into<CreateAlias>,
@@ -124,6 +239,22 @@ impl Qdrant {
         self.update_aliases(request.into()).await
     }
 
+    /// Delete existing collection name alias.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::CreateAliasBuilder;
+    ///
+    ///# async fn delete_alias(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .delete_alias("my_alias")
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/collections/#remove-alias>
     pub async fn delete_alias(
         &self,
         request: impl Into<DeleteAlias>,
@@ -131,6 +262,20 @@ impl Qdrant {
         self.update_aliases(request.into()).await
     }
 
+    /// Rename existing collection name alias.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::RenameAliasBuilder;
+    ///
+    ///# async fn rename_alias(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .rename_alias(RenameAliasBuilder::new("old_alias", "new_alias"))
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
     pub async fn rename_alias(
         &self,
         request: impl Into<RenameAlias>,
@@ -138,7 +283,16 @@ impl Qdrant {
         self.update_aliases(request.into()).await
     }
 
-    pub async fn update_aliases(
+    /// Update a collection name alias.
+    ///
+    /// Create, rename or delete a collection alias.
+    ///
+    /// To do this, use:
+    ///
+    /// - [`create_alias`](Self::create_alias)
+    /// - [`rename_alias`](Self::rename_alias)
+    /// - [`delete_alias`](Self::delete_alias)
+    async fn update_aliases(
         &self,
         change_aliases: impl Into<alias_operations::Action> + Clone,
     ) -> QdrantResult<CollectionOperationResponse> {
@@ -156,6 +310,18 @@ impl Qdrant {
         .await
     }
 
+    /// List collection name aliases for a specific collection.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    ///# async fn list_collection_aliases(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client.list_collection_aliases("my_collection").await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/collections/#list-collection-aliases>
     pub async fn list_collection_aliases(
         &self,
         request: impl Into<ListCollectionAliasesRequest>,
@@ -170,6 +336,21 @@ impl Qdrant {
         .await
     }
 
+    /// List collection name aliases for all collections.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    ///# async fn list_aliases(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client.list_aliases().await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// This only lists collection name aliases. To list collection names, use
+    /// [`list_collections`](Self::list_collections).
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/collections/#list-all-aliases>
     pub async fn list_aliases(&self) -> QdrantResult<ListAliasesResponse> {
         self.with_collections_client(|mut collection_api| async move {
             let result = collection_api.list_aliases(ListAliasesRequest {}).await?;
@@ -178,6 +359,18 @@ impl Qdrant {
         .await
     }
 
+    /// List cluster info of a collection.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    ///# async fn collection_cluster_info(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client.collection_cluster_info("my_collection").await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/collections/#collection-info>
     pub async fn collection_cluster_info(
         &self,
         request: impl Into<CollectionClusterInfoRequest>,
@@ -192,6 +385,36 @@ impl Qdrant {
         .await
     }
 
+    /// Update collection cluster setup.
+    ///
+    /// Execute a collection cluster
+    /// [`Operation`](crate::qdrant::update_collection_cluster_setup_request::Operation), such as
+    /// [`MoveShard`](crate::qdrant::MoveShard), [`ReplicateShard`](crate::qdrant::ReplicateShard)
+    /// or [`CreateShardKey`](crate::qdrant::CreateShardKey).
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{MoveShard, UpdateCollectionClusterSetupRequestBuilder};
+    ///
+    ///# async fn update_collection_cluster_setup(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .update_collection_cluster_setup(
+    ///         UpdateCollectionClusterSetupRequestBuilder::new("my_collection")
+    ///             .operation(MoveShard {
+    ///                 shard_id: 0,
+    ///                 to_shard_id: None,
+    ///                 from_peer_id: 0,
+    ///                 to_peer_id: 1,
+    ///                 method: None,
+    ///             })
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/collections/#create-a-collection>
     pub async fn update_collection_cluster_setup(
         &self,
         request: impl Into<UpdateCollectionClusterSetupRequest>,

--- a/src/qdrant_client/config.rs
+++ b/src/qdrant_client/config.rs
@@ -109,6 +109,9 @@ impl QdrantConfig {
     }
 }
 
+/// Default Qdrant client configuration.
+///
+/// Connects to `http://localhost:6334` without an API key.
 impl Default for QdrantConfig {
     fn default() -> Self {
         Self {

--- a/src/qdrant_client/error.rs
+++ b/src/qdrant_client/error.rs
@@ -4,13 +4,16 @@ use tonic::codegen::http::uri::InvalidUri;
 /// Qdrant client error
 #[derive(Error, Debug)]
 pub enum QdrantError {
-    /// API response error
+    /// Qdrant server responded with an error
     #[error("Error in the response: {}", .status.code())]
     ResponseError {
         /// gRPC status code
         status: tonic::Status,
     },
 
+    /// Conversion of a Rust into an API type failed
+    ///
+    /// Such error may include trying to convert a sparse vector into a dense vector.
     #[error("Error in conversion: {}", .0)]
     ConversionError(String),
 
@@ -22,7 +25,7 @@ pub enum QdrantError {
     #[error("No snapshot found for collection: {}", .0)]
     NoSnapshotFound(String),
 
-    /// IO error
+    /// Generic IO error
     #[error("IO error: {}", .0)]
     Io(#[from] std::io::Error),
 

--- a/src/qdrant_client/mod.rs
+++ b/src/qdrant_client/mod.rs
@@ -29,6 +29,34 @@ pub type QdrantBuilder = QdrantConfig;
 /// Qdrant client
 ///
 /// Connects to a Qdrant server and provides an API interface.
+///
+/// # Connect
+///
+/// Connect to a Qdrant instance with just an [URL](Qdrant::from_url):
+///
+/// ```no_run
+/// use qdrant_client::Qdrant;
+///
+///# async fn connect() -> Result<(), qdrant_client::QdrantError> {
+/// let client = Qdrant::from_url("http://localhost:6334").build()?;
+///# Ok(())
+///# }
+/// ```
+///
+/// Connect to a Qdrant instance with an [URL](Qdrant::from_url),
+/// [API key](QdrantBuilder::with_api_key) and [timeout](QdrantBuilder::with_timeout):
+///
+/// ```no_run
+/// use qdrant_client::Qdrant;
+///
+///# async fn connect() -> Result<(), qdrant_client::QdrantError> {
+/// let client = Qdrant::from_url("http://localhost:6334")
+///     .with_api_key(std::env::var("QDRANT_API_KEY"))
+///     .with_timeout(std::time::Duration::from_secs(10))
+///     .build()?;
+///# Ok(())
+///# }
+/// ```
 pub struct Qdrant {
     /// Client configuration
     pub config: QdrantConfig,

--- a/src/qdrant_client/mod.rs
+++ b/src/qdrant_client/mod.rs
@@ -57,6 +57,15 @@ pub type QdrantBuilder = QdrantConfig;
 ///# Ok(())
 ///# }
 /// ```
+///
+/// # Operations
+///
+/// Common operations include:
+///
+/// - [`create_collection`](Qdrant::create_collection) - Create a new collection
+/// - [`upsert_points`](Qdrant::upsert_points) - Insert or update points
+/// - [`search_points`](Qdrant::search_points) - Search points with similarity search
+/// - [All operations](Qdrant#implementations)
 pub struct Qdrant {
     /// Client configuration
     pub config: QdrantConfig,

--- a/src/qdrant_client/mod.rs
+++ b/src/qdrant_client/mod.rs
@@ -74,12 +74,11 @@ pub struct Qdrant {
     channel: ChannelPool,
 }
 
+/// Methods to construct a new Qdrant client.
 impl Qdrant {
-    /// Create a builder to setup the client
-    pub fn from_url(url: &str) -> QdrantBuilder {
-        QdrantBuilder::from_url(url)
-    }
-
+    /// Create a new Qdrant client.
+    ///
+    /// If no client client configuration is given the [default](QdrantConfig::default) is used.
     pub fn new(config: Option<QdrantConfig>) -> QdrantResult<Self> {
         let config = config.unwrap_or_default();
 
@@ -93,6 +92,22 @@ impl Qdrant {
         let client = Self { channel, config };
 
         Ok(client)
+    }
+
+    /// Build a new Qdrant client with the given URL.
+    ///
+    /// ```no_run
+    /// use qdrant_client::Qdrant;
+    ///
+    ///# async fn connect() -> Result<(), qdrant_client::QdrantError> {
+    /// let client = Qdrant::from_url("http://localhost:6334").build()?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// See more ways to connect [here](Self#connect).
+    pub fn from_url(url: &str) -> QdrantBuilder {
+        QdrantBuilder::from_url(url)
     }
 
     /// Wraps a channel with a token interceptor
@@ -126,6 +141,18 @@ impl Qdrant {
         Ok(result)
     }
 
+    /// Health check.
+    ///
+    /// Do a health check and fetch server information such as the current version and commit.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    ///# async fn list_collections(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client.health_check().await?;
+    ///# Ok(())
+    ///# }
+    /// ```
     pub async fn health_check(&self) -> QdrantResult<HealthCheckReply> {
         self.with_root_qdrant_client(|mut qdrant_api| async move {
             let result = qdrant_api.health_check(HealthCheckRequest {}).await?;

--- a/src/qdrant_client/points.rs
+++ b/src/qdrant_client/points.rs
@@ -95,7 +95,7 @@ impl Qdrant {
         .await
     }
 
-    /// Update or insert points into the collection.
+    /// Insert or update points into the collection.
     /// If points with given ID already exist, they will be overwritten.
     /// Also this method does not split the points to insert to avoid timeouts.
     /// Look at [`upsert_points_batch`](Self::upsert_points_batch) for that.
@@ -110,7 +110,7 @@ impl Qdrant {
         .await
     }
 
-    /// Update or insert points into the collection, splitting in chunks.
+    /// Insert or update points into the collection, splitting in chunks.
     /// If points with given ID already exist, they will be overwritten.
     pub async fn upsert_points_batch(
         &self,

--- a/src/qdrant_client/points.rs
+++ b/src/qdrant_client/points.rs
@@ -19,6 +19,9 @@ use crate::qdrant::{
 };
 use crate::qdrant_client::{Qdrant, QdrantResult};
 
+/// Point operations.
+///
+/// Manage points, vectors and payloads. Search and explore them.
 impl Qdrant {
     pub(crate) async fn with_points_client<T, O: Future<Output = Result<T, Status>>>(
         &self,
@@ -44,6 +47,29 @@ impl Qdrant {
         Ok(result)
     }
 
+    /// Search points in a collection.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{Condition, Filter, SearchParamsBuilder, SearchPointsBuilder};
+    ///
+    ///# async fn search_points(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .search_points(
+    ///         SearchPointsBuilder::new("my_collection", vec![0.2, 0.1, 0.9, 0.7], 3)
+    ///             .filter(Filter::must([Condition::matches(
+    ///                 "city",
+    ///                 "London".to_string(),
+    ///             )]))
+    ///             .params(SearchParamsBuilder::default().hnsw_ef(128).exact(false)),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/search/#search-api>
     pub async fn search_points(
         &self,
         request: impl Into<SearchPoints>,
@@ -57,6 +83,33 @@ impl Qdrant {
         .await
     }
 
+    /// Batch multiple points searches in a collection.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{Condition, Filter, SearchBatchPointsBuilder, SearchPointsBuilder,};
+    ///
+    ///# async fn search_batch_points(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// let filter = Filter::must([Condition::matches("city", "London".to_string())]);
+    ///
+    /// let searches = vec![
+    ///     SearchPointsBuilder::new("my_collection", vec![0.2, 0.1, 0.9, 0.7], 3)
+    ///         .filter(filter.clone())
+    ///         .build(),
+    ///     SearchPointsBuilder::new("my_collection", vec![0.5, 0.3, 0.2, 0.3], 3)
+    ///         .filter(filter)
+    ///         .build(),
+    /// ];
+    ///
+    /// client
+    ///     .search_batch_points(SearchBatchPointsBuilder::new("my_collection", searches))
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/search/#batch-search-api>
     pub async fn search_batch_points(
         &self,
         request: impl Into<SearchBatchPoints>,
@@ -70,6 +123,28 @@ impl Qdrant {
         .await
     }
 
+    /// Search points in a collection and group results by a payload field.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::SearchPointGroupsBuilder;
+    ///
+    ///# async fn search_points(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .search_groups(SearchPointGroupsBuilder::new(
+    ///         "my_collection", // Collection name
+    ///         vec![1.1],       // Search vector
+    ///         4,               // Search limit
+    ///         "document_id",   // Group by field
+    ///         2,               // Group size
+    ///     ))
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/search/#search-groups>
     pub async fn search_groups(
         &self,
         request: impl Into<SearchPointGroups>,
@@ -83,22 +158,61 @@ impl Qdrant {
         .await
     }
 
-    pub async fn batch_updates(
-        &self,
-        request: impl Into<UpdateBatchPoints>,
-    ) -> QdrantResult<UpdateBatchResponse> {
-        let request = &request.into();
-
-        self.with_points_client(|mut points_api| async move {
-            Ok(points_api.update_batch(request.clone()).await?.into_inner())
-        })
-        .await
-    }
-
-    /// Insert or update points into the collection.
-    /// If points with given ID already exist, they will be overwritten.
-    /// Also this method does not split the points to insert to avoid timeouts.
-    /// Look at [`upsert_points_batch`](Self::upsert_points_batch) for that.
+    /// Insert or update points in a collection.
+    ///
+    /// If points with the specified IDs already exist, they will be overwritten.
+    ///
+    /// All points are upserted in a single operation. For a large number of points you likley want
+    /// split all upsertions into separate operations to avoid timing out. You can use
+    /// [`upsert_points_chunked`](Self::upsert_points_chunked) to automatically do that for you.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::Payload;
+    /// use qdrant_client::qdrant::{PointStruct, UpsertPointsBuilder};
+    /// use serde_json::json;
+    ///
+    ///# async fn upsert_points(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .upsert_points(
+    ///         UpsertPointsBuilder::new(
+    ///             "my_collection",
+    ///             vec![
+    ///                 PointStruct::new(
+    ///                     1,
+    ///                     vec![0.9, 0.1, 0.1],
+    ///                     Payload::try_from(json!(
+    ///                         {"color": "red"}
+    ///                     ))
+    ///                     .unwrap(),
+    ///                 ),
+    ///                 PointStruct::new(
+    ///                     2,
+    ///                     vec![0.1, 0.9, 0.1],
+    ///                     Payload::try_from(json!(
+    ///                         {"color": "green"}
+    ///                     ))
+    ///                     .unwrap(),
+    ///                 ),
+    ///                 PointStruct::new(
+    ///                     3,
+    ///                     vec![0.1, 0.1, 0.9],
+    ///                     Payload::try_from(json!(
+    ///                         {"color": "blue"}
+    ///                     ))
+    ///                     .unwrap(),
+    ///                 ),
+    ///             ],
+    ///         )
+    ///         .wait(true),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/points/#upload-points>
     pub async fn upsert_points(
         &self,
         request: impl Into<UpsertPoints>,
@@ -110,9 +224,11 @@ impl Qdrant {
         .await
     }
 
-    /// Insert or update points into the collection, splitting in chunks.
-    /// If points with given ID already exist, they will be overwritten.
-    pub async fn upsert_points_batch(
+    /// Insert or update points in a collection.
+    ///
+    /// The same as [`upsert_points`](Self::upsert_points), but it automatically splits all points
+    /// into chunks of `chunk_size` to prevent timing out.
+    pub async fn upsert_points_chunked(
         &self,
         request: impl Into<UpsertPoints>,
         chunk_size: usize,
@@ -149,6 +265,39 @@ impl Qdrant {
         .await
     }
 
+    /// Set payload of points.
+    ///
+    /// Sets only the given payload values on a point, leaving other existing payloads in place.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::Payload;
+    /// use qdrant_client::qdrant::{PointsIdsList, SetPayloadPointsBuilder};
+    /// use serde_json::json;
+    ///
+    ///# async fn set_payload(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// let payload: Payload = json!({
+    ///     "property1": "string",
+    ///     "property2": "string",
+    /// })
+    /// .try_into()
+    /// .unwrap();
+    ///
+    /// client
+    ///     .set_payload(
+    ///         SetPayloadPointsBuilder::new("my_collection", payload)
+    ///             .points_selector(PointsIdsList {
+    ///                 ids: vec![0.into(), 3.into(), 10.into()],
+    ///             })
+    ///             .wait(true),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/payload/#set-payload>
     pub async fn set_payload(
         &self,
         request: impl Into<SetPayloadPoints>,
@@ -162,6 +311,41 @@ impl Qdrant {
         .await
     }
 
+    /// Overwrite payload of points.
+    ///
+    /// Sets the given payload values on a point, completely replacing existing payload.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::Payload;
+    /// use qdrant_client::qdrant::{
+    ///     points_selector::PointsSelectorOneOf, PointsIdsList, SetPayloadPointsBuilder,
+    /// };
+    /// use serde_json::json;
+    ///
+    ///# async fn overwrite_payload(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// let payload: Payload = json!({
+    ///     "property1": "string",
+    ///     "property2": "string",
+    /// })
+    /// .try_into()
+    /// .unwrap();
+    ///
+    /// client
+    ///     .overwrite_payload(
+    ///         SetPayloadPointsBuilder::new("my_collection", payload)
+    ///             .points_selector(PointsSelectorOneOf::Points(PointsIdsList {
+    ///                 ids: vec![0.into(), 3.into(), 10.into()],
+    ///             }))
+    ///             .wait(true),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/payload/#overwrite-payload>
     pub async fn overwrite_payload(
         &self,
         request: impl Into<SetPayloadPoints>,
@@ -175,6 +359,31 @@ impl Qdrant {
         .await
     }
 
+    /// Delete specified payload keys of points.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{DeletePayloadPointsBuilder, PointsIdsList};
+    ///
+    ///# async fn delete_payload(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .delete_payload(
+    ///         DeletePayloadPointsBuilder::new(
+    ///             "my_collection",
+    ///             vec!["color".to_string(), "price".to_string()],
+    ///         )
+    ///         .points_selector(PointsIdsList {
+    ///             ids: vec![0.into(), 3.into(), 100.into()],
+    ///         })
+    ///         .wait(true),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/payload/#delete-payload-keys>
     pub async fn delete_payload(
         &self,
         request: impl Into<DeletePayloadPoints>,
@@ -188,6 +397,26 @@ impl Qdrant {
         .await
     }
 
+    /// Clear all payload of points.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{ClearPayloadPointsBuilder, PointsIdsList};
+    ///
+    ///# async fn clear_payload(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .clear_payload(ClearPayloadPointsBuilder::new("my_collection").points(
+    ///         PointsIdsList {
+    ///             ids: vec![0.into(), 3.into(), 100.into()],
+    ///         },
+    ///     ))
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/payload/#clear-payload>
     pub async fn clear_payload(
         &self,
         request: impl Into<ClearPayloadPoints>,
@@ -201,6 +430,34 @@ impl Qdrant {
         .await
     }
 
+    /// Retrieve specific points from a collection.
+    ///
+    /// Use [`with_vectors`](crate::qdrant::GetPointsBuilder::with_vectors) and
+    /// [`with_payload`](crate::qdrant::GetPointsBuilder::with_payload) to specify whether to
+    /// include or exclude vector and payload data in the response. By default they are excluded to
+    /// save bandwidth.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::GetPointsBuilder;
+    ///
+    ///# async fn get_points(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .get_points(
+    ///         GetPointsBuilder::new(
+    ///             "my_collection",
+    ///             vec![0.into(), 30.into(), 100.into()],
+    ///         )
+    ///         .with_vectors(true)
+    ///         .with_payload(true)
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/points/#retrieve-points>
     pub async fn get_points(&self, request: impl Into<GetPoints>) -> QdrantResult<GetResponse> {
         let request = &request.into();
 
@@ -211,6 +468,52 @@ impl Qdrant {
         .await
     }
 
+    /// Delete points from a collection.
+    ///
+    /// Delete by point ID:
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{DeletePointsBuilder, PointsIdsList};
+    ///
+    ///# async fn delete_points(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .delete_points(
+    ///         DeletePointsBuilder::new("my_collection")
+    ///             .points(PointsIdsList {
+    ///                 ids: vec![0.into(), 3.into(), 100.into()],
+    ///             })
+    ///             .wait(true),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Or delete by [`Filter`](crate::qdrant::Filter):
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{Condition, DeletePointsBuilder, Filter};
+    ///
+    ///# async fn delete_points(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .delete_points(
+    ///         DeletePointsBuilder::new("my_collection")
+    ///             .points(Filter::must([Condition::matches(
+    ///                 "color",
+    ///                 "red".to_string(),
+    ///             )]))
+    ///             .wait(true),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/points/#delete-points>
     pub async fn delete_points(
         &self,
         request: impl Into<DeletePoints>,
@@ -224,6 +527,34 @@ impl Qdrant {
         .await
     }
 
+    /// Delete vectors from points.
+    ///
+    /// Removes specified vectors from points in a collection, leaving existing vectors on these
+    /// points with a different name in place.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{DeletePointVectorsBuilder, PointsIdsList, VectorsSelector};
+    ///
+    ///# async fn delete_vectors(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .delete_vectors(
+    ///         DeletePointVectorsBuilder::new("my_collection")
+    ///             .points_selector(PointsIdsList {
+    ///                 ids: vec![0.into(), 3.into(), 10.into()],
+    ///             })
+    ///             .vectors(VectorsSelector {
+    ///                 names: vec!["text".into(), "image".into()],
+    ///             })
+    ///             .wait(true),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/points/#delete-vectors>
     pub async fn delete_vectors(
         &self,
         request: impl Into<DeletePointVectors>,
@@ -237,6 +568,50 @@ impl Qdrant {
         .await
     }
 
+    /// Update vectors on points.
+    ///
+    /// Updates the given vectors on points in a collection, leaving existing vectors on these points
+    /// with a different name in place.
+    ///
+    /// ```no_run
+    ///# use std::collections::HashMap;
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{PointVectors, UpdatePointVectorsBuilder};
+    ///
+    ///# async fn update_vectors(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .update_vectors(
+    ///         UpdatePointVectorsBuilder::new(
+    ///             "my_collection",
+    ///             vec![
+    ///                 PointVectors {
+    ///                     id: Some(1.into()),
+    ///                     vectors: Some(
+    ///                         HashMap::from([("image".to_string(), vec![0.1, 0.2, 0.3, 0.4])])
+    ///                             .into(),
+    ///                     ),
+    ///                 },
+    ///                 PointVectors {
+    ///                     id: Some(2.into()),
+    ///                     vectors: Some(
+    ///                         HashMap::from([(
+    ///                             "text".to_string(),
+    ///                             vec![0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2],
+    ///                         )])
+    ///                         .into(),
+    ///                     ),
+    ///                 },
+    ///             ],
+    ///         )
+    ///         .wait(true),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/points/#update-vectors>
     pub async fn update_vectors(
         &self,
         request: impl Into<UpdatePointVectors>,
@@ -250,6 +625,36 @@ impl Qdrant {
         .await
     }
 
+    /// Scroll points in a collection.
+    ///
+    /// Use [`with_vectors`](crate::qdrant::ScrollPointsBuilder::with_vectors) and
+    /// [`with_payload`](crate::qdrant::ScrollPointsBuilder::with_payload) to specify whether to
+    /// include or exclude vector and payload data in the response. By default they are excluded to
+    /// save bandwidth.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{Condition, Filter, ScrollPointsBuilder};
+    ///
+    ///# async fn scroll(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .scroll(
+    ///         ScrollPointsBuilder::new("my_collection")
+    ///             .filter(Filter::must([Condition::matches(
+    ///                 "color",
+    ///                 "red".to_string(),
+    ///             )]))
+    ///             .limit(1)
+    ///             .with_payload(true)
+    ///             .with_vectors(true),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/points/#scroll-points>
     pub async fn scroll(&self, request: impl Into<ScrollPoints>) -> QdrantResult<ScrollResponse> {
         let request = &request.into();
 
@@ -260,6 +665,34 @@ impl Qdrant {
         .await
     }
 
+    /// Recommend points in a collection.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{Condition, Filter, RecommendPointsBuilder, RecommendStrategy};
+    ///
+    ///# async fn recommend(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .recommend(
+    ///         RecommendPointsBuilder::new("my_collection", 3)
+    ///             .add_positive(100)
+    ///             .add_positive(200)
+    ///             .add_positive(vec![100.0, 231.0])
+    ///             .add_negative(718)
+    ///             .add_negative(vec![0.2, 0.3, 0.4, 0.5])
+    ///             .strategy(RecommendStrategy::AverageVector)
+    ///             .filter(Filter::must([Condition::matches(
+    ///                 "city",
+    ///                 "London".to_string(),
+    ///             )])),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/explore/#recommendation-api>
     pub async fn recommend(
         &self,
         request: impl Into<RecommendPoints>,
@@ -273,6 +706,42 @@ impl Qdrant {
         .await
     }
 
+    /// Batch multiple points recommendations in a collection.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{Condition, Filter, RecommendBatchPointsBuilder, RecommendPointsBuilder};
+    ///
+    ///# async fn recommend_batch(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// let filter = Filter::must([Condition::matches("city", "London".to_string())]);
+    ///
+    /// let recommend_queries = vec![
+    ///     RecommendPointsBuilder::new("my_collection", 3)
+    ///         .add_positive(100)
+    ///         .add_positive(231)
+    ///         .add_negative(718)
+    ///         .filter(filter.clone())
+    ///         .build(),
+    ///     RecommendPointsBuilder::new("my_collection", 3)
+    ///         .add_positive(200)
+    ///         .add_positive(67)
+    ///         .add_negative(300)
+    ///         .filter(filter.clone())
+    ///         .build(),
+    /// ];
+    ///
+    /// client
+    ///     .recommend_batch(RecommendBatchPointsBuilder::new(
+    ///         "my_collection",
+    ///         recommend_queries,
+    ///     ))
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/explore/#batch-recommendation-api>
     pub async fn recommend_batch(
         &self,
         request: impl Into<RecommendBatchPoints>,
@@ -286,6 +755,33 @@ impl Qdrant {
         .await
     }
 
+    /// Recommend points in a collection and group results by a payload field.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{RecommendPointGroupsBuilder, RecommendStrategy};
+    ///
+    ///# async fn recommend_groups(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .recommend_groups(
+    ///         RecommendPointGroupsBuilder::new(
+    ///             "my_collection", // Collection name
+    ///             "document_id",   // Group by field
+    ///             2,               // Group size
+    ///             3,               // Search limit
+    ///         )
+    ///         .add_positive(100)
+    ///         .add_positive(200)
+    ///         .add_negative(718)
+    ///         .strategy(RecommendStrategy::AverageVector),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/explore/#recommendation-api>
     pub async fn recommend_groups(
         &self,
         request: impl Into<RecommendPointGroups>,
@@ -299,6 +795,43 @@ impl Qdrant {
         .await
     }
 
+    /// Discover points in a collection.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{
+    ///     target_vector::Target, vector_example::Example, ContextExamplePairBuilder,
+    ///     DiscoverPointsBuilder, VectorExample,
+    /// };
+    ///
+    ///# async fn discover(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .discover(
+    ///         DiscoverPointsBuilder::new(
+    ///             "my_collection", // Collection name
+    ///             vec![
+    ///                 ContextExamplePairBuilder::default()
+    ///                     .positive(Example::Id(100.into()))
+    ///                     .negative(Example::Id(718.into()))
+    ///                     .build(),
+    ///                 ContextExamplePairBuilder::default()
+    ///                     .positive(Example::Id(200.into()))
+    ///                     .negative(Example::Id(300.into()))
+    ///                     .build(),
+    ///             ],
+    ///             10,              // Search limit
+    ///         )
+    ///         .target(Target::Single(VectorExample {
+    ///             example: Some(Example::Vector(vec![0.2, 0.1, 0.9, 0.7].into())),
+    ///         })),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/explore/#discovery-api>
     pub async fn discover(
         &self,
         request: impl Into<DiscoverPoints>,
@@ -312,6 +845,59 @@ impl Qdrant {
         .await
     }
 
+    /// Batch multiple point discoveries in a collection.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{
+    ///     vector_example::Example, ContextExamplePairBuilder, DiscoverBatchPointsBuilder,
+    ///     DiscoverPointsBuilder,
+    /// };
+    ///
+    ///# async fn discover_batch(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// let discover_points = DiscoverBatchPointsBuilder::new(
+    ///     "my_collection",
+    ///     vec![
+    ///         DiscoverPointsBuilder::new(
+    ///             "my_collection",
+    ///             vec![
+    ///                 ContextExamplePairBuilder::default()
+    ///                     .positive(Example::Id(100.into()))
+    ///                     .negative(Example::Id(718.into()))
+    ///                     .build(),
+    ///                 ContextExamplePairBuilder::default()
+    ///                     .positive(Example::Id(200.into()))
+    ///                     .negative(Example::Id(300.into()))
+    ///                     .build(),
+    ///             ],
+    ///             10,
+    ///         )
+    ///         .build(),
+    ///         DiscoverPointsBuilder::new(
+    ///             "my_collection",
+    ///             vec![
+    ///                 ContextExamplePairBuilder::default()
+    ///                     .positive(Example::Id(342.into()))
+    ///                     .negative(Example::Id(213.into()))
+    ///                     .build(),
+    ///                 ContextExamplePairBuilder::default()
+    ///                     .positive(Example::Id(100.into()))
+    ///                     .negative(Example::Id(200.into()))
+    ///                     .build(),
+    ///             ],
+    ///             10,
+    ///         )
+    ///         .build(),
+    ///     ],
+    /// );
+    ///
+    /// client.discover_batch(&discover_points.build()).await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/explore/#discovery-api>
     pub async fn discover_batch(
         &self,
         request: &DiscoverBatchPoints,
@@ -323,6 +909,32 @@ impl Qdrant {
         .await
     }
 
+    /// Count points in a collection.
+    ///
+    /// Use [`exact`](crate::qdrant::CountPointsBuilder::exact) to specify whether to use exact
+    /// counting. Exact counting is more accurate but slower.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{Condition, CountPointsBuilder, Filter};
+    ///
+    ///# async fn count(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .count(
+    ///         CountPointsBuilder::new("collection_name")
+    ///             .filter(Filter::must([Condition::matches(
+    ///                 "color",
+    ///                 "red".to_string(),
+    ///             )]))
+    ///             .exact(true),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/points/#counting-points>
     pub async fn count(&self, request: impl Into<CountPoints>) -> QdrantResult<CountResponse> {
         let request = &request.into();
 
@@ -333,7 +945,74 @@ impl Qdrant {
         .await
     }
 
-    pub async fn update_batch_points(
+    /// Batch point updates in a collection.
+    ///
+    /// Execute a batch of point [updates](crate::qdrant::points_update_operation::Operation) in a single operation.
+    ///
+    /// ```no_run
+    ///# use std::collections::HashMap;
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::Payload;
+    /// use qdrant_client::qdrant::{
+    ///     points_selector::PointsSelectorOneOf,
+    ///     points_update_operation::{
+    ///         Operation, OverwritePayload, PointStructList, UpdateVectors,
+    ///     },
+    ///     PointStruct, PointVectors, PointsIdsList, PointsSelector, PointsUpdateOperation,
+    ///     UpdateBatchPointsBuilder,
+    /// };
+    /// use serde_json::json;
+    ///
+    ///# async fn update_batch_points(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .update_points_batch(
+    ///         UpdateBatchPointsBuilder::new(
+    ///             "my_collection",
+    ///             vec![
+    ///                 PointsUpdateOperation {
+    ///                     operation: Some(Operation::Upsert(PointStructList {
+    ///                         points: vec![PointStruct::new(
+    ///                             1,
+    ///                             vec![1.0, 2.0, 3.0, 4.0],
+    ///                             Payload::try_from(json!({})).unwrap(),
+    ///                         )],
+    ///                         ..Default::default()
+    ///                     })),
+    ///                 },
+    ///                 PointsUpdateOperation {
+    ///                     operation: Some(Operation::UpdateVectors(UpdateVectors {
+    ///                         points: vec![PointVectors {
+    ///                             id: Some(1.into()),
+    ///                             vectors: Some(vec![1.0, 2.0, 3.0, 4.0].into()),
+    ///                         }],
+    ///                         ..Default::default()
+    ///                     })),
+    ///                 },
+    ///                 PointsUpdateOperation {
+    ///                     operation: Some(Operation::OverwritePayload(OverwritePayload {
+    ///                         points_selector: Some(PointsSelector {
+    ///                             points_selector_one_of: Some(PointsSelectorOneOf::Points(
+    ///                                 PointsIdsList {
+    ///                                     ids: vec![1.into()],
+    ///                                 },
+    ///                             )),
+    ///                         }),
+    ///                         payload: HashMap::from([("test_payload".to_string(), 1.into())]),
+    ///                         ..Default::default()
+    ///                     })),
+    ///                 },
+    ///             ],
+    ///         )
+    ///         .wait(true),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/points/#batch-update>
+    pub async fn update_points_batch(
         &self,
         request: impl Into<UpdateBatchPoints>,
     ) -> QdrantResult<UpdateBatchResponse> {
@@ -346,7 +1025,29 @@ impl Qdrant {
         .await
     }
 
-    /// Create index for a payload field
+    /// Create payload index in a collection.
+    ///
+    /// ```no_run
+    ///# use std::collections::HashMap;
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{CreateFieldIndexCollectionBuilder, FieldType};
+    ///
+    ///# async fn create_field_index(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .create_field_index(
+    ///         CreateFieldIndexCollectionBuilder::new(
+    ///             "my_collection",
+    ///             "city",
+    ///             FieldType::Keyword,
+    ///         ),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/indexing/#payload-index>
     pub async fn create_field_index(
         &self,
         request: impl Into<CreateFieldIndexCollection>,
@@ -360,6 +1061,26 @@ impl Qdrant {
         .await
     }
 
+    /// Delete payload index from a collection.
+    ///
+    /// ```no_run
+    ///# use std::collections::HashMap;
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::DeleteFieldIndexCollectionBuilder;
+    ///
+    ///# async fn create_field_index(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .delete_field_index(DeleteFieldIndexCollectionBuilder::new(
+    ///         "my_collection",
+    ///         "city",
+    ///     ))
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/indexing/#payload-index>
     pub async fn delete_field_index(
         &self,
         request: impl Into<DeleteFieldIndexCollection>,

--- a/src/qdrant_client/query.rs
+++ b/src/qdrant_client/query.rs
@@ -2,7 +2,38 @@ use super::QdrantResult;
 use crate::qdrant::{QueryPoints, QueryResponse};
 use crate::qdrant_client::Qdrant;
 
+/// Point query operations.
+///
+/// Query points using the universal search API.
+///
+/// <!-- TODO: update documentation link to universal search API once released -->
+///
+/// Documentation: <https://qdrant.tech/documentation/concepts/search/#search-api>
 impl Qdrant {
+    /// Query a collection.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::{Condition, Filter, QueryPointsBuilder};
+    ///
+    ///# async fn query(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .query(
+    ///         QueryPointsBuilder::new("my_collection")
+    ///             .filter(Filter::must([Condition::matches(
+    ///                 "city",
+    ///                 "London".to_string(),
+    ///             )]))
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// <!-- TODO: update documentation link to universal search API once released -->
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/concepts/search/#search-api>
     pub async fn query(&self, request: impl Into<QueryPoints>) -> QdrantResult<QueryResponse> {
         let request = &request.into();
 

--- a/src/qdrant_client/sharding_keys.rs
+++ b/src/qdrant_client/sharding_keys.rs
@@ -3,7 +3,34 @@ use crate::qdrant::{
 };
 use crate::qdrant_client::{Qdrant, QdrantResult};
 
+/// Sharding key operations.
+///
+/// Create or delete shard keys for collections.
+///
+/// Documentation: <https://qdrant.tech/documentation/guides/distributed_deployment/#user-defined-sharding>
 impl Qdrant {
+    /// Create new shard key in a collection.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::shard_key::Key;
+    /// use qdrant_client::qdrant::{CreateShardKeyBuilder, CreateShardKeyRequestBuilder};
+    ///
+    ///# async fn create_shard_key(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .create_shard_key(
+    ///         CreateShardKeyRequestBuilder::new("my_collection").request(
+    ///             CreateShardKeyBuilder::default()
+    ///                 .shard_key(Key::Keyword("my_key".to_string())),
+    ///         ),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/guides/distributed_deployment/#user-defined-sharding>
     pub async fn create_shard_key(
         &self,
         request: impl Into<CreateShardKeyRequest>,
@@ -17,6 +44,28 @@ impl Qdrant {
         .await
     }
 
+    /// Delete existing shard key from a collection.
+    ///
+    /// Deleting a shard key destroys all shards and data placed in it.
+    ///
+    /// ```no_run
+    ///# use qdrant_client::{Qdrant, QdrantError};
+    /// use qdrant_client::qdrant::shard_key::Key;
+    /// use qdrant_client::qdrant::DeleteShardKeyRequestBuilder;
+    ///
+    ///# async fn delete_shard_key(client: &Qdrant)
+    ///# -> Result<(), QdrantError> {
+    /// client
+    ///     .delete_shard_key(
+    ///         DeleteShardKeyRequestBuilder::new("my_collection")
+    ///             .key(Key::Keyword("my_key".to_string())),
+    ///     )
+    ///     .await?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    ///
+    /// Documentation: <https://qdrant.tech/documentation/guides/distributed_deployment/#user-defined-sharding>
     pub async fn delete_shard_key(
         &self,
         request: impl Into<DeleteShardKeyRequest>,

--- a/tests/snippet_tests/test_batch_update.rs
+++ b/tests/snippet_tests/test_batch_update.rs
@@ -4,7 +4,6 @@ async fn test_batch_update() {
     async fn batch_update() -> Result<(), Box<dyn std::error::Error>> {
       // WARNING: This is a generated test snippet.
       // Please, modify the snippet in the `../snippets/batch_update.rs` file
-        use qdrant_client::client::Payload;
         use qdrant_client::qdrant::{
             points_selector::PointsSelectorOneOf,
             points_update_operation::{
@@ -13,14 +12,14 @@ async fn test_batch_update() {
             PointStruct, PointVectors, PointsIdsList, PointsSelector, PointsUpdateOperation,
             UpdateBatchPointsBuilder,
         };
-        use qdrant_client::Qdrant;
+        use qdrant_client::{Qdrant, Payload};
         use serde_json::json;
         use std::collections::HashMap;
         
         let client = Qdrant::from_url("http://localhost:6334").build()?;
         
         client
-            .batch_updates(
+            .update_points_batch(
                 UpdateBatchPointsBuilder::new(
                     "{collection_name}",
                     vec![

--- a/tests/snippet_tests/test_create_shard_key.rs
+++ b/tests/snippet_tests/test_create_shard_key.rs
@@ -14,7 +14,7 @@ async fn test_create_shard_key() {
             .create_shard_key(
                 CreateShardKeyRequestBuilder::new("{collection_name}").request(
                     CreateShardKeyBuilder::default()
-                        .shard_key(Key::Keyword("{shard_key".to_string())),
+                        .shard_key(Key::Keyword("{shard_key}".to_string())),
                 ),
             )
             .await?;

--- a/tests/snippet_tests/test_delete_shard_key.rs
+++ b/tests/snippet_tests/test_delete_shard_key.rs
@@ -13,7 +13,7 @@ async fn test_delete_shard_key() {
         client
             .delete_shard_key(
                 DeleteShardKeyRequestBuilder::new("{collection_name}")
-                    .key(Key::Keyword("{shard_key".to_string())),
+                    .key(Key::Keyword("{shard_key}".to_string())),
             )
             .await?;
         Ok(())

--- a/tests/snippet_tests/test_overwrite_payload.rs
+++ b/tests/snippet_tests/test_overwrite_payload.rs
@@ -4,11 +4,10 @@ async fn test_overwrite_payload() {
     async fn overwrite_payload() -> Result<(), Box<dyn std::error::Error>> {
       // WARNING: This is a generated test snippet.
       // Please, modify the snippet in the `../snippets/overwrite_payload.rs` file
-        use qdrant_client::client::Payload;
         use qdrant_client::qdrant::{
             points_selector::PointsSelectorOneOf, PointsIdsList, SetPayloadPointsBuilder,
         };
-        use qdrant_client::Qdrant;
+        use qdrant_client::{Qdrant, Payload};
         use serde_json::json;
         
         let client = Qdrant::from_url("http://localhost:6334").build()?;

--- a/tests/snippet_tests/test_scroll_points.rs
+++ b/tests/snippet_tests/test_scroll_points.rs
@@ -4,8 +4,7 @@ async fn test_scroll_points() {
     async fn scroll_points() -> Result<(), Box<dyn std::error::Error>> {
       // WARNING: This is a generated test snippet.
       // Please, modify the snippet in the `../snippets/scroll_points.rs` file
-        use qdrant_client::qdrant::ScrollPointsBuilder;
-        use qdrant_client::qdrant::{Condition, Filter};
+        use qdrant_client::qdrant::{Condition, Filter, ScrollPointsBuilder};
         use qdrant_client::Qdrant;
         
         let client = Qdrant::from_url("http://localhost:6334").build()?;

--- a/tests/snippet_tests/test_set_payload.rs
+++ b/tests/snippet_tests/test_set_payload.rs
@@ -4,9 +4,8 @@ async fn test_set_payload() {
     async fn set_payload() -> Result<(), Box<dyn std::error::Error>> {
       // WARNING: This is a generated test snippet.
       // Please, modify the snippet in the `../snippets/set_payload.rs` file
-        use qdrant_client::client::Payload;
         use qdrant_client::qdrant::{PointsIdsList, SetPayloadPointsBuilder};
-        use qdrant_client::Qdrant;
+        use qdrant_client::{Qdrant, Payload};
         use serde_json::json;
         
         let client = Qdrant::from_url("http://localhost:6334").build()?;

--- a/tests/snippet_tests/test_upsert_points.rs
+++ b/tests/snippet_tests/test_upsert_points.rs
@@ -4,9 +4,8 @@ async fn test_upsert_points() {
     async fn upsert_points() -> Result<(), Box<dyn std::error::Error>> {
       // WARNING: This is a generated test snippet.
       // Please, modify the snippet in the `../snippets/upsert_points.rs` file
-        use qdrant_client::prelude::{Payload, PointStruct};
-        use qdrant_client::qdrant::UpsertPointsBuilder;
-        use qdrant_client::Qdrant;
+        use qdrant_client::qdrant::{PointStruct, UpsertPointsBuilder};
+        use qdrant_client::{Qdrant, Payload};
         use serde_json::json;
         
         let client = Qdrant::from_url("http://localhost:6334").build()?;

--- a/tests/snippets/batch_update.rs
+++ b/tests/snippets/batch_update.rs
@@ -1,4 +1,3 @@
-use qdrant_client::client::Payload;
 use qdrant_client::qdrant::{
     points_selector::PointsSelectorOneOf,
     points_update_operation::{
@@ -7,14 +6,14 @@ use qdrant_client::qdrant::{
     PointStruct, PointVectors, PointsIdsList, PointsSelector, PointsUpdateOperation,
     UpdateBatchPointsBuilder,
 };
-use qdrant_client::Qdrant;
+use qdrant_client::{Qdrant, Payload};
 use serde_json::json;
 use std::collections::HashMap;
 
 let client = Qdrant::from_url("http://localhost:6334").build()?;
 
 client
-    .batch_updates(
+    .update_points_batch(
         UpdateBatchPointsBuilder::new(
             "{collection_name}",
             vec![

--- a/tests/snippets/create_shard_key.rs
+++ b/tests/snippets/create_shard_key.rs
@@ -8,7 +8,7 @@ client
     .create_shard_key(
         CreateShardKeyRequestBuilder::new("{collection_name}").request(
             CreateShardKeyBuilder::default()
-                .shard_key(Key::Keyword("{shard_key".to_string())),
+                .shard_key(Key::Keyword("{shard_key}".to_string())),
         ),
     )
     .await?;

--- a/tests/snippets/delete_shard_key.rs
+++ b/tests/snippets/delete_shard_key.rs
@@ -7,6 +7,6 @@ let client = Qdrant::from_url("http://localhost:6334").build()?;
 client
     .delete_shard_key(
         DeleteShardKeyRequestBuilder::new("{collection_name}")
-            .key(Key::Keyword("{shard_key".to_string())),
+            .key(Key::Keyword("{shard_key}".to_string())),
     )
     .await?;

--- a/tests/snippets/overwrite_payload.rs
+++ b/tests/snippets/overwrite_payload.rs
@@ -1,8 +1,7 @@
-use qdrant_client::client::Payload;
 use qdrant_client::qdrant::{
     points_selector::PointsSelectorOneOf, PointsIdsList, SetPayloadPointsBuilder,
 };
-use qdrant_client::Qdrant;
+use qdrant_client::{Qdrant, Payload};
 use serde_json::json;
 
 let client = Qdrant::from_url("http://localhost:6334").build()?;

--- a/tests/snippets/scroll_points.rs
+++ b/tests/snippets/scroll_points.rs
@@ -1,5 +1,4 @@
-use qdrant_client::qdrant::ScrollPointsBuilder;
-use qdrant_client::qdrant::{Condition, Filter};
+use qdrant_client::qdrant::{Condition, Filter, ScrollPointsBuilder};
 use qdrant_client::Qdrant;
 
 let client = Qdrant::from_url("http://localhost:6334").build()?;

--- a/tests/snippets/set_payload.rs
+++ b/tests/snippets/set_payload.rs
@@ -1,6 +1,5 @@
-use qdrant_client::client::Payload;
 use qdrant_client::qdrant::{PointsIdsList, SetPayloadPointsBuilder};
-use qdrant_client::Qdrant;
+use qdrant_client::{Qdrant, Payload};
 use serde_json::json;
 
 let client = Qdrant::from_url("http://localhost:6334").build()?;

--- a/tests/snippets/upsert_points.rs
+++ b/tests/snippets/upsert_points.rs
@@ -1,6 +1,5 @@
-use qdrant_client::prelude::{Payload, PointStruct};
-use qdrant_client::qdrant::UpsertPointsBuilder;
-use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{PointStruct, UpsertPointsBuilder};
+use qdrant_client::{Qdrant, Payload};
 use serde_json::json;
 
 let client = Qdrant::from_url("http://localhost:6334").build()?;


### PR DESCRIPTION
This PR adds makes various improvements around the crate documentation.

It is quite big, and I don't expect others to go through it line by line. It does not have code/logic changes. Examples are sourced from our test snippets.

As always, inspect these changes locally with: `cargo doc --no-deps --open`

It adds a basic connection example (and adds a Qdrant logo):

![image](https://github.com/qdrant/rust-client/assets/856222/f666d3a5-4886-480f-90ab-79cbde7ac144)

It adds basic operation documentation, a minimal example and links to our main documentation:

![image](https://github.com/qdrant/rust-client/assets/856222/d7065bf4-614e-4efa-a79f-6532ef477164)

It hides deprecated modules:

![image](https://github.com/qdrant/rust-client/assets/856222/dc91105e-98b8-49f7-8015-5e0cf674f311)

Amongst other things.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?