### PR TITLE
Simplify JSON to/from Payload conversions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ pub mod error;
 pub mod prelude;
 /// Deprecated serde helper
 #[cfg(feature = "serde")]
-#[deprecated(since = "1.10.0", note = "use `Payload::from_json_object` instead")]
+#[deprecated(since = "1.10.0", note = "use `Payload::try_from` instead")]
 #[doc(hidden)]
 pub mod serde;
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -30,8 +30,8 @@ use crate::qdrant::Value;
 ///     "city": "Berlin",
 /// });
 ///
-/// let payload: Payload = Payload::try_from(value).expect("not a JSON object");
-/// let value: Value = Value::from(payload);
+/// let payload = Payload::try_from(value).expect("not a JSON object");
+/// let value = Value::from(payload);
 /// ```
 ///
 /// If the above value is not a JSON object, a [`QdrantError::JsonToPayload`](crate::QdrantError::JsonToPayload) error is returned.
@@ -45,8 +45,8 @@ use crate::qdrant::Value;
 /// let mut object = Map::new();
 /// object.insert("city".to_string(), "Berlin".into());
 ///
-/// let payload: Payload = Payload::from(object);
-/// let object: Map<String, Value> = Map::from(payload);
+/// let payload = Payload::from(object);
+/// let object = Map::from(payload);
 /// ```
 #[derive(Clone, PartialEq, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -12,6 +12,42 @@ use crate::qdrant::Value;
 /// values during vector search.
 ///
 /// Payload documentation: <https://qdrant.tech/documentation/concepts/payload/>
+///
+/// # Serde
+///
+/// <small><em>Requires `serde` feature</em></small>
+///
+/// [Serde JSON](serde_json) types can be converted to and from [`Payload`]. Note that a valid
+/// payload must be a JSON object, and not another JSON type.
+///
+/// Convert a JSON [`Value`](serde_json::Value) to and from [`Payload`]:
+///
+/// ```rust
+///# use qdrant_client::Payload;
+/// use serde_json::{Value, json};
+///
+/// let value = json!({
+///     "city": "Berlin",
+/// });
+///
+/// let payload: Payload = Payload::try_from(value).expect("not a JSON object");
+/// let value: Value = Value::from(payload);
+/// ```
+///
+/// If the above value is not a JSON object, a [`QdrantError::JsonToPayload`](crate::QdrantError::JsonToPayload) error is returned.
+///
+/// Convert a JSON object ([`Map<String, Value>`](serde_json::Map)) to and from from [`Payload`]:
+///
+/// ```rust
+///# use qdrant_client::Payload;
+/// use serde_json::{Map, Value};
+///
+/// let mut object = Map::new();
+/// object.insert("city".to_string(), "Berlin".into());
+///
+/// let payload: Payload = Payload::from(object);
+/// let object: Map<String, Value> = Map::from(payload);
+/// ```
 #[derive(Clone, PartialEq, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Payload(pub(crate) HashMap<String, Value>);

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -61,6 +61,26 @@ impl From<Payload> for HashMap<String, Value> {
 }
 
 #[cfg(feature = "serde")]
+impl From<Payload> for serde_json::Value {
+    #[inline]
+    fn from(value: Payload) -> serde_json::Value {
+        serde_json::Value::Object(value.into())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl From<Payload> for serde_json::Map<String, serde_json::Value> {
+    #[inline]
+    fn from(value: Payload) -> serde_json::Map<String, serde_json::Value> {
+        value
+            .0
+            .into_iter()
+            .map(|(k, v)| (k, v.into()))
+            .collect::<serde_json::Map<String, serde_json::Value>>()
+    }
+}
+
+#[cfg(feature = "serde")]
 impl TryFrom<serde_json::Value> for Payload {
     type Error = crate::QdrantError;
 

--- a/src/qdrant_client/error.rs
+++ b/src/qdrant_client/error.rs
@@ -33,6 +33,11 @@ pub enum QdrantError {
     #[cfg(feature = "reqwest")]
     #[error("Reqwest error: {}", .0)]
     Reqwest(#[from] reqwest::Error),
+
+    /// JSON to payload conversion error, only JSON objects are supported
+    #[cfg(feature = "serde")]
+    #[error("JSON cannot be converted to payload, only JSON objects are supported")]
+    JsonToPayload(serde_json::Value),
 }
 
 impl From<tonic::Status> for QdrantError {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -6,11 +6,14 @@ use std::fmt::{Display, Formatter};
 use serde::ser::{SerializeMap, SerializeSeq};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::client::Payload;
 use crate::qdrant::value::Kind;
 use crate::qdrant::{ListValue, Struct, Value};
 
 #[derive(Debug)]
+#[deprecated(
+    since = "1.10.0",
+    note = "use `qdrant_client::Error::JsonToPayload` error variant instead"
+)]
 pub struct PayloadConversionError(serde_json::Value);
 
 impl Display for PayloadConversionError {
@@ -96,18 +99,6 @@ impl From<serde_json::Value> for Value {
                         .collect::<HashMap<_, _>>(),
                 })),
             },
-        }
-    }
-}
-
-impl TryFrom<serde_json::Value> for Payload {
-    type Error = PayloadConversionError;
-
-    fn try_from(value: serde_json::Value) -> Result<Self, Self::Error> {
-        if let serde_json::Value::Object(object) = value {
-            Ok(object.into())
-        } else {
-            Err(PayloadConversionError(value))
         }
     }
 }


### PR DESCRIPTION
This simplifies conversions between JSON and Payload in both directions. It adds a new error variant (`QdrantError::JsonToPayload`) and replaces the convoluted and isolated error type we had for this before.

It also replaces the `Payload::from_json_object` I had added with `Payload::try_from`.

I've added documentation for this to clearly show how to convert between the types:

![image](https://github.com/qdrant/rust-client/assets/856222/556e9a3f-ea19-4614-9b61-cae42bdfa907)

The change does not introduce any new problems with the top 12 crates using `qdrant_client`. It therefore seems good enough in terms of backwards compatibility.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?