### PR TITLE
Fix constant CI failures with protobuf installation, match core repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,10 @@ jobs:
       - name: Install minimal stable
         uses: dtolnay/rust-toolchain@stable
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: sudo apt-get update; sudo apt-get upgrade -y; sudo apt-get install protobuf-compiler
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run integration tests
         run: |
           ./tests/integration-tests.sh


### PR DESCRIPTION
We had constant CI errors due to inconsistent protobuf versions.

This updates our CI to use the same way of installing protobuf related dependencies as we do in the core repository here: https://github.com/qdrant/qdrant/blob/5c29cad76edc4fe33882d385c02633352666d67e/.github/workflows/rust.yml#L24-L27

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?