### PR TITLE
Bump version to 1.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant-client"
-version = "1.9.0"
+version = "1.10.0"
 edition = "2021"
 authors = ["Qdrant Team <team@qdrant.com>"]
 description = "Rust client for Qdrant Vector Search Engine"


### PR DESCRIPTION
Release version 1.10.0 of the Rust client.

This is a huge release. We can elaborate on this in the change log when publishing the release tag.

### Tasks
- [ ] On release, also merge <https://github.com/qdrant/api-reference/pull/22>