### PR TITLE
Convert string slice into PointId

### DIFF
--- a/src/grpc_conversions/primitives.rs
+++ b/src/grpc_conversions/primitives.rs
@@ -186,6 +186,12 @@ impl From<String> for PointId {
     }
 }
 
+impl From<&str> for PointId {
+    fn from(val: &str) -> Self {
+        Self::from(val.to_string())
+    }
+}
+
 impl From<u64> for PointId {
     fn from(val: u64) -> Self {
         Self {


### PR DESCRIPTION
Support

```rust
PointId::new("43cf51e2-8777-4f52-bc74-c2cbde0c8b04")
```

instead of just

```rust
PointId::new("43cf51e2-8777-4f52-bc74-c2cbde0c8b04".to_string())
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?