### PR TITLE
Expose (Sparse)VectorsConfigBuilder

### DIFF
--- a/src/qdrant_client/builders/mod.rs
+++ b/src/qdrant_client/builders/mod.rs
@@ -1,6 +1,14 @@
-pub mod payloads;
-pub mod query;
+mod payloads;
+mod query;
+// Keeping this public because 1.10-1.10.1 users may use it
 pub mod sparse_vectors_config;
-pub mod vector_input;
-pub mod vectors;
-pub mod vectors_config;
+mod vector_input;
+mod vectors;
+mod vectors_config;
+
+// We must re-export here because the above modules are overwritten with generated modules in
+// qdrant.rs due to name collisions.
+
+// Re-exports
+pub use self::sparse_vectors_config::SparseVectorsConfigBuilder;
+pub use self::vectors_config::VectorsConfigBuilder;

--- a/src/qdrant_client/query.rs
+++ b/src/qdrant_client/query.rs
@@ -95,11 +95,9 @@ mod tests {
         DiscoverInputBuilder, Distance, FieldType, Fusion, IntegerIndexParamsBuilder, Modifier,
         MultiVectorConfig, NamedVectors, PointId, PointStruct, PrefetchQueryBuilder, Query,
         QueryPointsBuilder, RecommendInputBuilder, ScalarQuantizationBuilder,
-        SparseIndexConfigBuilder, SparseVectorParamsBuilder, UpsertPointsBuilder, Vector,
-        VectorInput, VectorParamsBuilder,
+        SparseIndexConfigBuilder, SparseVectorParamsBuilder, SparseVectorsConfigBuilder,
+        UpsertPointsBuilder, Vector, VectorInput, VectorParamsBuilder, VectorsConfigBuilder,
     };
-    use crate::qdrant_client::builders::sparse_vectors_config::SparseVectorsConfigBuilder;
-    use crate::qdrant_client::builders::vectors_config::VectorsConfigBuilder;
     use crate::Payload;
 
     #[tokio::test]


### PR DESCRIPTION
We had the `VectorsConfigBuilder` in place before, but it was silently hidden.

We did expose it through the `vectors_config` module. However, our generated `qdrant.rs` has the exact same module name in it. Due to the name collision our builder types was silently ignored.

We now explicitly expose `VectorsConfigBuilder` and `SparseVectorsConfigBuilder` in `qdrant.rs` directly to prevent this problem:

- `qdrant_client::qdrant::VectorsConfigBuilder`
- `qdrant_client::qdrant::SparseVectorsConfigBuilder`

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?