### PR TITLE
Index params improvements

### DIFF
--- a/src/qdrant.rs
+++ b/src/qdrant.rs
@@ -3532,7 +3532,13 @@ pub struct CreateFieldIndexCollection {
     pub field_type: ::core::option::Option<i32>,
     /// Payload index params.
     #[prost(message, optional, tag = "5")]
-    #[builder(default, setter(into, strip_option), field(vis = "pub(crate)"))]
+    #[builder(
+        setter(into, strip_option),
+        field(
+            ty = "Option<payload_index_params::IndexParams>",
+            build = "convert_option(&self.field_index_params)"
+        )
+    )]
     pub field_index_params: ::core::option::Option<PayloadIndexParams>,
     /// Write ordering guarantees
     #[prost(message, optional, tag = "6")]

--- a/src/qdrant_client/conversions/payloads.rs
+++ b/src/qdrant_client/conversions/payloads.rs
@@ -1,5 +1,8 @@
 use crate::qdrant::payload_index_params::IndexParams;
-use crate::qdrant::{IntegerIndexParams, PayloadIndexParams, TextIndexParams};
+use crate::qdrant::{
+    IntegerIndexParams, IntegerIndexParamsBuilder, KeywordIndexParams, KeywordIndexParamsBuilder,
+    PayloadIndexParams, TextIndexParams, TextIndexParamsBuilder,
+};
 
 impl From<IndexParams> for PayloadIndexParams {
     fn from(value: IndexParams) -> Self {
@@ -15,9 +18,29 @@ impl From<TextIndexParams> for IndexParams {
     }
 }
 
+impl From<TextIndexParamsBuilder> for IndexParams {
+    fn from(value: TextIndexParamsBuilder) -> Self {
+        Self::TextIndexParams(value.build())
+    }
+}
+
+impl From<TextIndexParams> for PayloadIndexParams {
+    fn from(value: TextIndexParams) -> Self {
+        Self {
+            index_params: Some(IndexParams::from(value)),
+        }
+    }
+}
+
 impl From<IntegerIndexParams> for IndexParams {
     fn from(value: IntegerIndexParams) -> Self {
         Self::IntegerIndexParams(value)
+    }
+}
+
+impl From<IntegerIndexParamsBuilder> for IndexParams {
+    fn from(value: IntegerIndexParamsBuilder) -> Self {
+        Self::IntegerIndexParams(value.build())
     }
 }
 
@@ -29,10 +52,14 @@ impl From<IntegerIndexParams> for PayloadIndexParams {
     }
 }
 
-impl From<TextIndexParams> for PayloadIndexParams {
-    fn from(value: TextIndexParams) -> Self {
-        Self {
-            index_params: Some(IndexParams::from(value)),
-        }
+impl From<KeywordIndexParams> for IndexParams {
+    fn from(value: KeywordIndexParams) -> Self {
+        Self::KeywordIndexParams(value)
+    }
+}
+
+impl From<KeywordIndexParamsBuilder> for IndexParams {
+    fn from(value: KeywordIndexParamsBuilder) -> Self {
+        Self::KeywordIndexParams(value.build())
     }
 }

--- a/tests/protos.rs
+++ b/tests/protos.rs
@@ -613,7 +613,7 @@ fn configure_builder(builder: Builder) -> Builder {
             ("CreateFieldIndexCollection.field_type", DEFAULT_OPTION_INTO),
             (
                 "CreateFieldIndexCollection.field_index_params",
-                DEFAULT_OPTION_INTO,
+                builder_custom_into!(payload_index_params::IndexParams, self.field_index_params),
             ),
             ("CreateFieldIndexCollection.ordering", DEFAULT_OPTION_INTO),
             // DeleteFieldIndexCollection


### PR DESCRIPTION
Depends on #168 

Improves configuring field index:

From
```rust
.field_index_params(PayloadIndexParams {
    index_params: Some(IndexParams::KeywordIndexParams(
        KeywordIndexParamsBuilder::default()
            .is_tenant(true)
            .build(),
    )),
})
```

To
```rust
.field_index_params(
    KeywordIndexParamsBuilder::default()
        .is_tenant(true),
)

```