### PR TITLE
Bump version to 1.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant-client"
-version = "1.10.3"
+version = "1.11.0"
 edition = "2021"
 authors = ["Qdrant Team <team@qdrant.com>"]
 description = "Rust client for Qdrant Vector Search Engine"


### PR DESCRIPTION
Cut 1.11.0 release.

Next task is to create tag + GH release to publish crate.