### PR TITLE
Fix empty points update request when data is smaller than chunk size

### DIFF
--- a/src/qdrant_client/points.rs
+++ b/src/qdrant_client/points.rs
@@ -120,14 +120,13 @@ impl Qdrant {
         chunk_size: usize,
     ) -> QdrantResult<PointsOperationResponse> {
         let mut request = request.into();
-        let points = std::mem::take(&mut request.points);
 
-        if points.len() < chunk_size {
+        if request.points.len() < chunk_size {
             return self.upsert_points(request).await;
         }
 
+        let points = &std::mem::take(&mut request.points);
         let request = &request;
-        let points = &points;
 
         self.with_points_client(|mut points_api| async move {
             let mut resp = PointsOperationResponse {


### PR DESCRIPTION
Fixes <https://github.com/qdrant/rust-client/issues/174>.

Fix `upsert_points_chunked` doing an empty point update if the list of points is smaller than the specified chunk size.

This happened because we cleared the list of points before short cutting to a regular point update if the above condition was met.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?