### PR TITLE
Include actual server error message in reporting

### DIFF
--- a/src/qdrant_client/error.rs
+++ b/src/qdrant_client/error.rs
@@ -5,7 +5,7 @@ use tonic::codegen::http::uri::InvalidUri;
 #[derive(Error, Debug)]
 pub enum QdrantError {
     /// Qdrant server responded with an error
-    #[error("Error in the response: {}", .status.code())]
+    #[error("Error in the response: {} {}", .status.code(), .status.message())]
     ResponseError {
         /// gRPC status code
         status: tonic::Status,


### PR DESCRIPTION
This PR improves the error reporting when the server returns an error to return the full error message.

This is needed because it is currently very difficult for a user to understand why a request fails without looking into the server logs.

For instance when trying to create a malformed collection the client yields: 

```
Error in the response: Client specified an invalid argument
```

However the server logs say:

```
INFO qdrant::tonic::logging: gRPC /qdrant.Collections/Create failed with Client specified an invalid argument "Wrong input: `shard_number` cannot be 0"
```

With this PR the users will see the message as well.
