### PR TITLE
Bump version to 1.11.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant-client"
-version = "1.11.1"
+version = "1.11.2"
 edition = "2021"
 authors = ["Qdrant Team <team@qdrant.com>"]
 description = "Rust client for Qdrant Vector Search Engine"


### PR DESCRIPTION
A patch release (1.11.2) to include an important improvement to error reporting https://github.com/qdrant/rust-client/pull/185.