### PR TITLE
Demote protos generation panic to log message

### DIFF
--- a/tests/protos.rs
+++ b/tests/protos.rs
@@ -50,7 +50,7 @@ fn protos() {
     append_to_file(GRPC_OUTPUT_FILE, "pub use prost_types::Timestamp;");
 
     eprintln!("protos_files_synced:{protos_files_synced}, protos_test_synced:{protos_test_synced}");
-    panic!("proto definitions changed. Stubs recompiled. Please commit the changes.")
+    eprintln!("proto definitions may be changed. Stubs recompiled. Please commit the changes.")
 }
 
 /// Derive options for structs. (Path, build attributes, 'from' macro generation enabled)


### PR DESCRIPTION
This panic has been more annoying than helpful, so I suggest to demote it to just a warning message.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?