### PR TITLE
Replace macro generated builder types with unrolled ones

### DIFF
--- a/examples/search.rs
+++ b/examples/search.rs
@@ -1,6 +1,7 @@
+use qdrant_client::builders::CreateCollectionBuilder;
 use qdrant_client::qdrant::{
-    Condition, CreateCollectionBuilder, Distance, Filter, PointStruct, ScalarQuantizationBuilder,
-    SearchParamsBuilder, SearchPointsBuilder, UpsertPointsBuilder, VectorParamsBuilder,
+    Condition, Distance, Filter, PointStruct, ScalarQuantizationBuilder, SearchParamsBuilder,
+    SearchPointsBuilder, UpsertPointsBuilder, VectorParamsBuilder,
 };
 use qdrant_client::{Payload, Qdrant, QdrantError};
 

--- a/src/builder_ext.rs
+++ b/src/builder_ext.rs
@@ -3,23 +3,24 @@ use std::collections::HashMap;
 use crate::qdrant::update_collection_cluster_setup_request::Operation;
 use crate::qdrant::{
     shard_key, AbortShardTransferBuilder, BinaryQuantizationBuilder, ClearPayloadPointsBuilder,
-    ContextExamplePair, CountPointsBuilder, CreateAliasBuilder, CreateCollectionBuilder,
-    CreateFieldIndexCollectionBuilder, CreateShardKeyRequestBuilder, DeleteCollectionBuilder,
-    DeleteFieldIndexCollectionBuilder, DeletePayloadPointsBuilder, DeletePointVectorsBuilder,
-    DeletePointsBuilder, DeleteShardKey, DeleteShardKeyRequestBuilder,
-    DeleteSnapshotRequestBuilder, DiscoverBatchPointsBuilder, DiscoverPoints,
-    DiscoverPointsBuilder, Distance, FacetCountsBuilder, FieldType, GetPointsBuilder,
-    LookupLocationBuilder, MoveShardBuilder, PayloadExcludeSelector, PayloadIncludeSelector,
-    PointId, PointStruct, PointVectors, PointsUpdateOperation, ProductQuantizationBuilder,
-    QuantizationType, QueryBatchPointsBuilder, QueryPointGroupsBuilder, QueryPoints,
-    QueryPointsBuilder, RecommendBatchPointsBuilder, RecommendExample, RecommendPointGroupsBuilder,
-    RecommendPoints, RecommendPointsBuilder, RenameAliasBuilder, ReplicaBuilder,
-    ReplicateShardBuilder, ScalarQuantizationBuilder, ScrollPointsBuilder,
+    ContextExamplePair, CountPointsBuilder, CreateAliasBuilder, CreateFieldIndexCollectionBuilder,
+    CreateShardKeyRequestBuilder, DeleteCollectionBuilder, DeleteFieldIndexCollectionBuilder,
+    DeletePayloadPointsBuilder, DeletePointVectorsBuilder, DeletePointsBuilder, DeleteShardKey,
+    DeleteShardKeyRequestBuilder, DeleteSnapshotRequestBuilder, DiscoverBatchPointsBuilder,
+    DiscoverPoints, DiscoverPointsBuilder, Distance, FacetCountsBuilder, FieldType,
+    GetPointsBuilder, LookupLocationBuilder, MoveShardBuilder, PayloadExcludeSelector,
+    PayloadIncludeSelector, PointId, PointStruct, PointVectors, PointsUpdateOperation,
+    ProductQuantizationBuilder, QuantizationType, QueryBatchPointsBuilder, QueryPointGroupsBuilder,
+    QueryPoints, QueryPointsBuilder, RecommendBatchPointsBuilder, RecommendExample,
+    RecommendPointGroupsBuilder, RecommendPoints, RecommendPointsBuilder, RenameAliasBuilder,
+    ReplicaBuilder, ReplicateShardBuilder, ScalarQuantizationBuilder, ScrollPointsBuilder,
     SearchBatchPointsBuilder, SearchMatrixPointsBuilder, SearchPointGroupsBuilder, SearchPoints,
     SearchPointsBuilder, SetPayloadPointsBuilder, ShardKey, UpdateBatchPointsBuilder,
     UpdateCollectionBuilder, UpdateCollectionClusterSetupRequestBuilder, UpdatePointVectorsBuilder,
     UpsertPointsBuilder, Value, VectorParamsBuilder, VectorsSelector, WithLookupBuilder,
 };
+
+use crate::builders::CreateCollectionBuilder;
 
 impl VectorParamsBuilder {
     pub fn new(size: u64, distance: Distance) -> Self {

--- a/src/builders/abort_shard_transfer_builder.rs
+++ b/src/builders/abort_shard_transfer_builder.rs
@@ -1,0 +1,109 @@
+use crate::qdrant::*;
+
+pub struct AbortShardTransferBuilder {
+    /// Local shard id
+    pub(crate) shard_id: Option<u32>,
+    pub(crate) to_shard_id: Option<Option<u32>>,
+    pub(crate) from_peer_id: Option<u64>,
+    pub(crate) to_peer_id: Option<u64>,
+}
+
+impl AbortShardTransferBuilder {
+    /// Local shard id
+    #[allow(unused_mut)]
+    pub fn shard_id(self, value: u32) -> Self {
+        let mut new = self;
+        new.shard_id = Option::Some(value);
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn to_shard_id(self, value: u32) -> Self {
+        let mut new = self;
+        new.to_shard_id = Option::Some(Option::Some(value));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn from_peer_id(self, value: u64) -> Self {
+        let mut new = self;
+        new.from_peer_id = Option::Some(value);
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn to_peer_id(self, value: u64) -> Self {
+        let mut new = self;
+        new.to_peer_id = Option::Some(value);
+        new
+    }
+    /**Builds a new `AbortShardTransfer`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<AbortShardTransfer, AbortShardTransferBuilderError> {
+        Ok(AbortShardTransfer {
+            shard_id: match self.shard_id {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("shard_id"),
+                    ));
+                }
+            },
+            to_shard_id: match self.to_shard_id {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            from_peer_id: match self.from_peer_id {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("from_peer_id"),
+                    ));
+                }
+            },
+            to_peer_id: match self.to_peer_id {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("to_peer_id"),
+                    ));
+                }
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            shard_id: core::default::Default::default(),
+            to_shard_id: core::default::Default::default(),
+            from_peer_id: core::default::Default::default(),
+            to_peer_id: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<AbortShardTransferBuilder> for AbortShardTransfer {
+    fn from(value: AbortShardTransferBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "AbortShardTransferBuilder", "AbortShardTransfer",
+        ))
+    }
+}
+
+impl AbortShardTransferBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> AbortShardTransfer {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "AbortShardTransferBuilder", "AbortShardTransfer",
+        ))
+    }
+}
+
+impl AbortShardTransferBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/binary_quantization_builder.rs
+++ b/src/builders/binary_quantization_builder.rs
@@ -1,0 +1,61 @@
+use crate::qdrant::*;
+
+pub struct BinaryQuantizationBuilder {
+    /// If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
+    pub(crate) always_ram: Option<Option<bool>>,
+}
+
+impl BinaryQuantizationBuilder {
+    /// If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
+    #[allow(unused_mut)]
+    pub fn always_ram(self, value: bool) -> Self {
+        let mut new = self;
+        new.always_ram = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `BinaryQuantization`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<BinaryQuantization, BinaryQuantizationBuilderError> {
+        Ok(BinaryQuantization {
+            always_ram: match self.always_ram {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            always_ram: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<BinaryQuantizationBuilder> for BinaryQuantization {
+    fn from(value: BinaryQuantizationBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "BinaryQuantizationBuilder", "BinaryQuantization",
+        ))
+    }
+}
+
+impl BinaryQuantizationBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> BinaryQuantization {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "BinaryQuantizationBuilder", "BinaryQuantization",
+        ))
+    }
+}
+
+impl BinaryQuantizationBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/clear_payload_points_builder.rs
+++ b/src/builders/clear_payload_points_builder.rs
@@ -1,0 +1,125 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct ClearPayloadPointsBuilder {
+    /// name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Wait until the changes have been applied?
+    pub(crate) wait: Option<Option<bool>>,
+    /// Affected points
+    points: Option<points_selector::PointsSelectorOneOf>,
+    /// Write ordering guarantees
+    pub(crate) ordering: Option<Option<WriteOrdering>>,
+    /// Option for custom sharding to specify used shard keys
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+}
+
+impl ClearPayloadPointsBuilder {
+    /// name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Wait until the changes have been applied?
+    #[allow(unused_mut)]
+    pub fn wait(self, value: bool) -> Self {
+        let mut new = self;
+        new.wait = Option::Some(Option::Some(value));
+        new
+    }
+    /// Affected points
+    #[allow(unused_mut)]
+    pub fn points<VALUE: core::convert::Into<points_selector::PointsSelectorOneOf>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.points = Option::Some(value.into());
+        new
+    }
+    /// Write ordering guarantees
+    #[allow(unused_mut)]
+    pub fn ordering<VALUE: core::convert::Into<WriteOrdering>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.ordering = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Option for custom sharding to specify used shard keys
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `ClearPayloadPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<ClearPayloadPoints, ClearPayloadPointsBuilderError> {
+        Ok(ClearPayloadPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            wait: match self.wait {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            points: { convert_option(&self.points) },
+            ordering: match self.ordering {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            wait: core::default::Default::default(),
+            points: core::default::Default::default(),
+            ordering: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<ClearPayloadPointsBuilder> for ClearPayloadPoints {
+    fn from(value: ClearPayloadPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "ClearPayloadPointsBuilder", "ClearPayloadPoints",
+        ))
+    }
+}
+
+impl ClearPayloadPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> ClearPayloadPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "ClearPayloadPointsBuilder", "ClearPayloadPoints",
+        ))
+    }
+}
+
+impl ClearPayloadPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/collection_params_diff_builder.rs
+++ b/src/builders/collection_params_diff_builder.rs
@@ -1,0 +1,99 @@
+use crate::qdrant::*;
+
+pub struct CollectionParamsDiffBuilder {
+    /// Number of replicas of each shard that network tries to maintain
+    pub(crate) replication_factor: Option<Option<u32>>,
+    /// How many replicas should apply the operation for us to consider it successful
+    pub(crate) write_consistency_factor: Option<Option<u32>>,
+    /// If true - point's payload will not be stored in memory
+    pub(crate) on_disk_payload: Option<Option<bool>>,
+    /// Fan-out every read request to these many additional remote nodes (and return first available response)
+    pub(crate) read_fan_out_factor: Option<Option<u32>>,
+}
+#[allow(clippy::all)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[allow(dead_code)]
+impl CollectionParamsDiffBuilder {
+    /// Number of replicas of each shard that network tries to maintain
+    #[allow(unused_mut)]
+    pub fn replication_factor(self, value: u32) -> Self {
+        let mut new = self;
+        new.replication_factor = Option::Some(Option::Some(value));
+        new
+    }
+    /// How many replicas should apply the operation for us to consider it successful
+    #[allow(unused_mut)]
+    pub fn write_consistency_factor(self, value: u32) -> Self {
+        let mut new = self;
+        new.write_consistency_factor = Option::Some(Option::Some(value));
+        new
+    }
+    /// If true - point's payload will not be stored in memory
+    #[allow(unused_mut)]
+    pub fn on_disk_payload(self, value: bool) -> Self {
+        let mut new = self;
+        new.on_disk_payload = Option::Some(Option::Some(value));
+        new
+    }
+    /// Fan-out every read request to these many additional remote nodes (and return first available response)
+    #[allow(unused_mut)]
+    pub fn read_fan_out_factor(self, value: u32) -> Self {
+        let mut new = self;
+        new.read_fan_out_factor = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `CollectionParamsDiff`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<CollectionParamsDiff, std::convert::Infallible> {
+        Ok(CollectionParamsDiff {
+            replication_factor: match self.replication_factor {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            write_consistency_factor: match self.write_consistency_factor {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            on_disk_payload: match self.on_disk_payload {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            read_fan_out_factor: match self.read_fan_out_factor {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            replication_factor: core::default::Default::default(),
+            write_consistency_factor: core::default::Default::default(),
+            on_disk_payload: core::default::Default::default(),
+            read_fan_out_factor: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<CollectionParamsDiffBuilder> for CollectionParamsDiff {
+    fn from(value: CollectionParamsDiffBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "CollectionParamsDiffBuilder", "CollectionParamsDiff",
+        ))
+    }
+}
+
+impl CollectionParamsDiffBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> CollectionParamsDiff {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "CollectionParamsDiffBuilder", "CollectionParamsDiff",
+        ))
+    }
+}

--- a/src/builders/context_example_pair_builder.rs
+++ b/src/builders/context_example_pair_builder.rs
@@ -1,0 +1,65 @@
+use crate::qdrant::*;
+
+pub struct ContextExamplePairBuilder {
+    pub(crate) positive: Option<Option<VectorExample>>,
+    pub(crate) negative: Option<Option<VectorExample>>,
+}
+
+impl ContextExamplePairBuilder {
+    #[allow(unused_mut)]
+    pub fn positive<VALUE: core::convert::Into<VectorExample>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.positive = Option::Some(Option::Some(value.into()));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn negative<VALUE: core::convert::Into<VectorExample>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.negative = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `ContextExamplePair`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<ContextExamplePair, std::convert::Infallible> {
+        Ok(ContextExamplePair {
+            positive: match self.positive {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            negative: match self.negative {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            positive: core::default::Default::default(),
+            negative: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<ContextExamplePairBuilder> for ContextExamplePair {
+    fn from(value: ContextExamplePairBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "ContextExamplePairBuilder", "ContextExamplePair",
+        ))
+    }
+}
+
+impl ContextExamplePairBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> ContextExamplePair {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "ContextExamplePairBuilder", "ContextExamplePair",
+        ))
+    }
+}

--- a/src/builders/context_input_builder.rs
+++ b/src/builders/context_input_builder.rs
@@ -1,0 +1,55 @@
+use crate::qdrant::*;
+
+pub struct ContextInputBuilder {
+    /// Search space will be constrained by these pairs of vectors
+    pub(crate) pairs: Option<Vec<ContextInputPair>>,
+}
+
+impl ContextInputBuilder {
+    /// Search space will be constrained by these pairs of vectors
+    #[allow(unused_mut)]
+    pub fn pairs<VALUE: core::convert::Into<Vec<ContextInputPair>>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.pairs = Option::Some(value.into());
+        new
+    }
+    /**Builds a new `ContextInput`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<ContextInput, std::convert::Infallible> {
+        Ok(ContextInput {
+            pairs: match self.pairs {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            pairs: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<ContextInputBuilder> for ContextInput {
+    fn from(value: ContextInputBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "ContextInputBuilder", "ContextInput",
+        ))
+    }
+}
+
+impl ContextInputBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> ContextInput {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "ContextInputBuilder", "ContextInput",
+        ))
+    }
+}

--- a/src/builders/context_input_pair_builder.rs
+++ b/src/builders/context_input_pair_builder.rs
@@ -1,0 +1,75 @@
+use crate::qdrant::*;
+
+pub struct ContextInputPairBuilder {
+    /// A positive vector
+    pub(crate) positive: Option<Option<VectorInput>>,
+    /// Repel from this vector
+    pub(crate) negative: Option<Option<VectorInput>>,
+}
+
+impl ContextInputPairBuilder {
+    /// A positive vector
+    #[allow(unused_mut)]
+    pub fn positive<VALUE: core::convert::Into<VectorInput>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.positive = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Repel from this vector
+    #[allow(unused_mut)]
+    pub fn negative<VALUE: core::convert::Into<VectorInput>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.negative = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `ContextInputPair`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<ContextInputPair, ContextInputPairBuilderError> {
+        Ok(ContextInputPair {
+            positive: match self.positive {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            negative: match self.negative {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            positive: core::default::Default::default(),
+            negative: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<ContextInputPairBuilder> for ContextInputPair {
+    fn from(value: ContextInputPairBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "ContextInputPairBuilder", "ContextInputPair",
+        ))
+    }
+}
+
+impl ContextInputPairBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> ContextInputPair {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "ContextInputPairBuilder", "ContextInputPair",
+        ))
+    }
+}
+
+impl ContextInputPairBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/count_points_builder.rs
+++ b/src/builders/count_points_builder.rs
@@ -1,0 +1,139 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct CountPointsBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Filter conditions - return only those points that satisfy the specified conditions
+    pub(crate) filter: Option<Option<Filter>>,
+    /// If `true` - return exact count, if `false` - return approximate count
+    pub(crate) exact: Option<Option<bool>>,
+    /// Options for specifying read consistency guarantees
+    read_consistency: Option<read_consistency::Value>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+}
+
+impl CountPointsBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Filter conditions - return only those points that satisfy the specified conditions
+    #[allow(unused_mut)]
+    pub fn filter<VALUE: core::convert::Into<Filter>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.filter = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If `true` - return exact count, if `false` - return approximate count
+    #[allow(unused_mut)]
+    pub fn exact(self, value: bool) -> Self {
+        let mut new = self;
+        new.exact = Option::Some(Option::Some(value));
+        new
+    }
+    /// Options for specifying read consistency guarantees
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<read_consistency::Value>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(value.into());
+        new
+    }
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `CountPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<CountPoints, CountPointsBuilderError> {
+        Ok(CountPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            filter: match self.filter {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            exact: match self.exact {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            read_consistency: { convert_option(&self.read_consistency) },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            filter: core::default::Default::default(),
+            exact: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<CountPointsBuilder> for CountPoints {
+    fn from(value: CountPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "CountPointsBuilder", "CountPoints",
+        ))
+    }
+}
+
+impl CountPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> CountPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "CountPointsBuilder", "CountPoints",
+        ))
+    }
+}
+
+impl CountPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/create_alias_builder.rs
+++ b/src/builders/create_alias_builder.rs
@@ -1,0 +1,83 @@
+use crate::qdrant::*;
+
+pub struct CreateAliasBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// New name of the alias
+    pub(crate) alias_name: Option<String>,
+}
+
+impl CreateAliasBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// New name of the alias
+    #[allow(unused_mut)]
+    pub fn alias_name(self, value: String) -> Self {
+        let mut new = self;
+        new.alias_name = Option::Some(value);
+        new
+    }
+    /**Builds a new `CreateAlias`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<CreateAlias, CreateAliasBuilderError> {
+        Ok(CreateAlias {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            alias_name: match self.alias_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("alias_name"),
+                    ));
+                }
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            alias_name: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<CreateAliasBuilder> for CreateAlias {
+    fn from(value: CreateAliasBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "CreateAliasBuilder", "CreateAlias",
+        ))
+    }
+}
+
+impl CreateAliasBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> CreateAlias {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "CreateAliasBuilder", "CreateAlias",
+        ))
+    }
+}
+
+impl CreateAliasBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/create_collection_builder.rs
+++ b/src/builders/create_collection_builder.rs
@@ -1,0 +1,264 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+#[derive(Default, Debug)]
+pub struct CreateCollectionBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Configuration of vector index
+    pub(crate) hnsw_config: Option<Option<HnswConfigDiff>>,
+    /// Configuration of the Write-Ahead-Log
+    pub(crate) wal_config: Option<Option<WalConfigDiff>>,
+    /// Configuration of the optimizers
+    pub(crate) optimizers_config: Option<Option<OptimizersConfigDiff>>,
+    /// Number of shards in the collection, default is 1 for standalone, otherwise equal to the number of nodes. Minimum is 1
+    pub(crate) shard_number: Option<Option<u32>>,
+    /// If true - point's payload will not be stored in memory
+    pub(crate) on_disk_payload: Option<Option<bool>>,
+    /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+    pub(crate) timeout: Option<Option<u64>>,
+    /// Configuration for vectors
+    pub(crate) vectors_config: Option<Option<VectorsConfig>>,
+    /// Number of replicas of each shard that network tries to maintain, default = 1
+    pub(crate) replication_factor: Option<Option<u32>>,
+    /// How many replicas should apply the operation for us to consider it successful, default = 1
+    pub(crate) write_consistency_factor: Option<Option<u32>>,
+    /// Specify name of the other collection to copy data from
+    pub(crate) init_from_collection: Option<Option<String>>,
+    /// Quantization configuration of vector
+    quantization_config: Option<quantization_config::Quantization>,
+    /// Sharding method
+    pub(crate) sharding_method: Option<Option<i32>>,
+    /// Configuration for sparse vectors
+    pub(crate) sparse_vectors_config: Option<Option<SparseVectorConfig>>,
+    /// Configuration for strict mode
+    pub(crate) strict_mode_config: Option<Option<StrictModeConfig>>,
+}
+#[allow(clippy::all)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[allow(dead_code)]
+impl CreateCollectionBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name<VALUE: core::convert::Into<String>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value.into());
+        new
+    }
+    /// Configuration of vector index
+    #[allow(unused_mut)]
+    pub fn hnsw_config<VALUE: core::convert::Into<HnswConfigDiff>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.hnsw_config = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Configuration of the Write-Ahead-Log
+    #[allow(unused_mut)]
+    pub fn wal_config<VALUE: core::convert::Into<WalConfigDiff>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.wal_config = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Configuration of the optimizers
+    #[allow(unused_mut)]
+    pub fn optimizers_config<VALUE: core::convert::Into<OptimizersConfigDiff>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.optimizers_config = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Number of shards in the collection, default is 1 for standalone, otherwise equal to the number of nodes. Minimum is 1
+    #[allow(unused_mut)]
+    pub fn shard_number(self, value: u32) -> Self {
+        let mut new = self;
+        new.shard_number = Option::Some(Option::Some(value));
+        new
+    }
+    /// If true - point's payload will not be stored in memory
+    #[allow(unused_mut)]
+    pub fn on_disk_payload(self, value: bool) -> Self {
+        let mut new = self;
+        new.on_disk_payload = Option::Some(Option::Some(value));
+        new
+    }
+    /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /// Configuration for vectors
+    #[allow(unused_mut)]
+    pub fn vectors_config<VALUE: core::convert::Into<VectorsConfig>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.vectors_config = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Number of replicas of each shard that network tries to maintain, default = 1
+    #[allow(unused_mut)]
+    pub fn replication_factor(self, value: u32) -> Self {
+        let mut new = self;
+        new.replication_factor = Option::Some(Option::Some(value));
+        new
+    }
+    /// How many replicas should apply the operation for us to consider it successful, default = 1
+    #[allow(unused_mut)]
+    pub fn write_consistency_factor(self, value: u32) -> Self {
+        let mut new = self;
+        new.write_consistency_factor = Option::Some(Option::Some(value));
+        new
+    }
+    /// Specify name of the other collection to copy data from
+    #[allow(unused_mut)]
+    pub fn init_from_collection<VALUE: core::convert::Into<String>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.init_from_collection = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Quantization configuration of vector
+    #[allow(unused_mut)]
+    pub fn quantization_config<VALUE: core::convert::Into<quantization_config::Quantization>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.quantization_config = Option::Some(value.into());
+        new
+    }
+    /// Sharding method
+    #[allow(unused_mut)]
+    pub fn sharding_method(self, value: i32) -> Self {
+        let mut new = self;
+        new.sharding_method = Option::Some(Option::Some(value));
+        new
+    }
+    /// Configuration for sparse vectors
+    #[allow(unused_mut)]
+    pub fn sparse_vectors_config<VALUE: core::convert::Into<SparseVectorConfig>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.sparse_vectors_config = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Configuration for strict mode
+    #[allow(unused_mut)]
+    pub fn strict_mode_config<VALUE: core::convert::Into<StrictModeConfig>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.strict_mode_config = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `CreateCollection`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<CreateCollection, std::convert::Infallible> {
+        Ok(CreateCollection {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            hnsw_config: match self.hnsw_config {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            wal_config: match self.wal_config {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            optimizers_config: match self.optimizers_config {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_number: match self.shard_number {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            on_disk_payload: match self.on_disk_payload {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            vectors_config: match self.vectors_config {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            replication_factor: match self.replication_factor {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            write_consistency_factor: match self.write_consistency_factor {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            init_from_collection: match self.init_from_collection {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            quantization_config: { convert_option(&self.quantization_config) },
+            sharding_method: match self.sharding_method {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            sparse_vectors_config: match self.sparse_vectors_config {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            strict_mode_config: match self.strict_mode_config {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            hnsw_config: core::default::Default::default(),
+            wal_config: core::default::Default::default(),
+            optimizers_config: core::default::Default::default(),
+            shard_number: core::default::Default::default(),
+            on_disk_payload: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+            vectors_config: core::default::Default::default(),
+            replication_factor: core::default::Default::default(),
+            write_consistency_factor: core::default::Default::default(),
+            init_from_collection: core::default::Default::default(),
+            quantization_config: core::default::Default::default(),
+            sharding_method: core::default::Default::default(),
+            sparse_vectors_config: core::default::Default::default(),
+            strict_mode_config: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<CreateCollectionBuilder> for CreateCollection {
+    fn from(value: CreateCollectionBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "CreateCollectionBuilder", "CreateCollection",
+        ))
+    }
+}
+
+impl CreateCollectionBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> CreateCollection {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "CreateCollectionBuilder", "CreateCollection",
+        ))
+    }
+}

--- a/src/builders/create_field_index_collection_builder.rs
+++ b/src/builders/create_field_index_collection_builder.rs
@@ -1,0 +1,142 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct CreateFieldIndexCollectionBuilder {
+    /// name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Wait until the changes have been applied?
+    pub(crate) wait: Option<Option<bool>>,
+    /// Field name to index
+    pub(crate) field_name: Option<String>,
+    /// Field type.
+    pub(crate) field_type: Option<Option<i32>>,
+    /// Payload index params.
+    field_index_params: Option<payload_index_params::IndexParams>,
+    /// Write ordering guarantees
+    pub(crate) ordering: Option<Option<WriteOrdering>>,
+}
+
+impl CreateFieldIndexCollectionBuilder {
+    /// name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Wait until the changes have been applied?
+    #[allow(unused_mut)]
+    pub fn wait(self, value: bool) -> Self {
+        let mut new = self;
+        new.wait = Option::Some(Option::Some(value));
+        new
+    }
+    /// Field name to index
+    #[allow(unused_mut)]
+    pub fn field_name(self, value: String) -> Self {
+        let mut new = self;
+        new.field_name = Option::Some(value);
+        new
+    }
+    /// Field type.
+    #[allow(unused_mut)]
+    pub fn field_type<VALUE: core::convert::Into<i32>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.field_type = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Payload index params.
+    #[allow(unused_mut)]
+    pub fn field_index_params<VALUE: core::convert::Into<payload_index_params::IndexParams>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.field_index_params = Option::Some(value.into());
+        new
+    }
+    /// Write ordering guarantees
+    #[allow(unused_mut)]
+    pub fn ordering<VALUE: core::convert::Into<WriteOrdering>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.ordering = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `CreateFieldIndexCollection`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(
+        self,
+    ) -> Result<CreateFieldIndexCollection, CreateFieldIndexCollectionBuilderError> {
+        Ok(CreateFieldIndexCollection {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            wait: match self.wait {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            field_name: match self.field_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("field_name"),
+                    ));
+                }
+            },
+            field_type: match self.field_type {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            field_index_params: { convert_option(&self.field_index_params) },
+            ordering: match self.ordering {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            wait: core::default::Default::default(),
+            field_name: core::default::Default::default(),
+            field_type: core::default::Default::default(),
+            field_index_params: core::default::Default::default(),
+            ordering: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<CreateFieldIndexCollectionBuilder> for CreateFieldIndexCollection {
+    fn from(value: CreateFieldIndexCollectionBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "CreateFieldIndexCollectionBuilder", "CreateFieldIndexCollection",
+        ))
+    }
+}
+
+impl CreateFieldIndexCollectionBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> CreateFieldIndexCollection {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "CreateFieldIndexCollectionBuilder", "CreateFieldIndexCollection",
+        ))
+    }
+}
+
+impl CreateFieldIndexCollectionBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/create_shard_key_builder.rs
+++ b/src/builders/create_shard_key_builder.rs
@@ -1,0 +1,97 @@
+use crate::qdrant::*;
+
+pub struct CreateShardKeyBuilder {
+    /// User-defined shard key
+    pub(crate) shard_key: Option<Option<ShardKey>>,
+    /// Number of shards to create per shard key
+    pub(crate) shards_number: Option<Option<u32>>,
+    /// Number of replicas of each shard to create
+    pub(crate) replication_factor: Option<Option<u32>>,
+    /// List of peer ids, allowed to create shards. If empty - all peers are allowed
+    pub(crate) placement: Option<Vec<u64>>,
+}
+
+impl CreateShardKeyBuilder {
+    /// User-defined shard key
+    #[allow(unused_mut)]
+    pub fn shard_key<VALUE: core::convert::Into<ShardKey>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.shard_key = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Number of shards to create per shard key
+    #[allow(unused_mut)]
+    pub fn shards_number(self, value: u32) -> Self {
+        let mut new = self;
+        new.shards_number = Option::Some(Option::Some(value));
+        new
+    }
+    /// Number of replicas of each shard to create
+    #[allow(unused_mut)]
+    pub fn replication_factor(self, value: u32) -> Self {
+        let mut new = self;
+        new.replication_factor = Option::Some(Option::Some(value));
+        new
+    }
+    /// List of peer ids, allowed to create shards. If empty - all peers are allowed
+    #[allow(unused_mut)]
+    pub fn placement(self, value: Vec<u64>) -> Self {
+        let mut new = self;
+        new.placement = Option::Some(value);
+        new
+    }
+    /**Builds a new `CreateShardKey`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<CreateShardKey, std::convert::Infallible> {
+        Ok(CreateShardKey {
+            shard_key: match self.shard_key {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shards_number: match self.shards_number {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            replication_factor: match self.replication_factor {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            placement: match self.placement {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            shard_key: core::default::Default::default(),
+            shards_number: core::default::Default::default(),
+            replication_factor: core::default::Default::default(),
+            placement: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<CreateShardKeyBuilder> for CreateShardKey {
+    fn from(value: CreateShardKeyBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "CreateShardKeyBuilder", "CreateShardKey",
+        ))
+    }
+}
+
+impl CreateShardKeyBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> CreateShardKey {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "CreateShardKeyBuilder", "CreateShardKey",
+        ))
+    }
+}

--- a/src/builders/create_shard_key_request_builder.rs
+++ b/src/builders/create_shard_key_request_builder.rs
@@ -1,0 +1,93 @@
+use crate::qdrant::*;
+
+pub struct CreateShardKeyRequestBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Request to create shard key
+    pub(crate) request: Option<Option<CreateShardKey>>,
+    /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+    pub(crate) timeout: Option<Option<u64>>,
+}
+
+impl CreateShardKeyRequestBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Request to create shard key
+    #[allow(unused_mut)]
+    pub fn request<VALUE: core::convert::Into<CreateShardKey>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.request = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `CreateShardKeyRequest`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<CreateShardKeyRequest, CreateShardKeyRequestBuilderError> {
+        Ok(CreateShardKeyRequest {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            request: match self.request {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            request: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<CreateShardKeyRequestBuilder> for CreateShardKeyRequest {
+    fn from(value: CreateShardKeyRequestBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "CreateShardKeyRequestBuilder", "CreateShardKeyRequest",
+        ))
+    }
+}
+
+impl CreateShardKeyRequestBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> CreateShardKeyRequest {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "CreateShardKeyRequestBuilder", "CreateShardKeyRequest",
+        ))
+    }
+}
+
+impl CreateShardKeyRequestBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/datetime_index_params_builder.rs
+++ b/src/builders/datetime_index_params_builder.rs
@@ -1,0 +1,69 @@
+use crate::qdrant::*;
+
+pub struct DatetimeIndexParamsBuilder {
+    /// If true - store index on disk.
+    pub(crate) on_disk: Option<Option<bool>>,
+    /// If true - use this key to organize storage of the collection data. This option assumes that this key will be used in majority of filtered requests.
+    pub(crate) is_principal: Option<Option<bool>>,
+}
+
+impl DatetimeIndexParamsBuilder {
+    /// If true - store index on disk.
+    #[allow(unused_mut)]
+    pub fn on_disk(self, value: bool) -> Self {
+        let mut new = self;
+        new.on_disk = Option::Some(Option::Some(value));
+        new
+    }
+    /// If true - use this key to organize storage of the collection data. This option assumes that this key will be used in majority of filtered requests.
+    #[allow(unused_mut)]
+    pub fn is_principal(self, value: bool) -> Self {
+        let mut new = self;
+        new.is_principal = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `DatetimeIndexParams`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<DatetimeIndexParams, std::convert::Infallible> {
+        Ok(DatetimeIndexParams {
+            on_disk: match self.on_disk {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            is_principal: match self.is_principal {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            on_disk: core::default::Default::default(),
+            is_principal: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<DatetimeIndexParamsBuilder> for DatetimeIndexParams {
+    fn from(value: DatetimeIndexParamsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "DatetimeIndexParamsBuilder", "DatetimeIndexParams",
+        ))
+    }
+}
+
+impl DatetimeIndexParamsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> DatetimeIndexParams {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "DatetimeIndexParamsBuilder", "DatetimeIndexParams",
+        ))
+    }
+}

--- a/src/builders/delete_collection_builder.rs
+++ b/src/builders/delete_collection_builder.rs
@@ -1,0 +1,79 @@
+use crate::qdrant::*;
+
+pub struct DeleteCollectionBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+    pub(crate) timeout: Option<Option<u64>>,
+}
+
+impl DeleteCollectionBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `DeleteCollection`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<DeleteCollection, DeleteCollectionBuilderError> {
+        Ok(DeleteCollection {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<DeleteCollectionBuilder> for DeleteCollection {
+    fn from(value: DeleteCollectionBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "DeleteCollectionBuilder", "DeleteCollection",
+        ))
+    }
+}
+
+impl DeleteCollectionBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> DeleteCollection {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "DeleteCollectionBuilder", "DeleteCollection",
+        ))
+    }
+}
+
+impl DeleteCollectionBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/delete_field_index_collection_builder.rs
+++ b/src/builders/delete_field_index_collection_builder.rs
@@ -1,0 +1,113 @@
+use crate::qdrant::*;
+
+pub struct DeleteFieldIndexCollectionBuilder {
+    /// name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Wait until the changes have been applied?
+    pub(crate) wait: Option<Option<bool>>,
+    /// Field name to delete
+    pub(crate) field_name: Option<String>,
+    /// Write ordering guarantees
+    pub(crate) ordering: Option<Option<WriteOrdering>>,
+}
+
+impl DeleteFieldIndexCollectionBuilder {
+    /// name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Wait until the changes have been applied?
+    #[allow(unused_mut)]
+    pub fn wait(self, value: bool) -> Self {
+        let mut new = self;
+        new.wait = Option::Some(Option::Some(value));
+        new
+    }
+    /// Field name to delete
+    #[allow(unused_mut)]
+    pub fn field_name(self, value: String) -> Self {
+        let mut new = self;
+        new.field_name = Option::Some(value);
+        new
+    }
+    /// Write ordering guarantees
+    #[allow(unused_mut)]
+    pub fn ordering(self, value: WriteOrdering) -> Self {
+        let mut new = self;
+        new.ordering = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `DeleteFieldIndexCollection`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(
+        self,
+    ) -> Result<DeleteFieldIndexCollection, DeleteFieldIndexCollectionBuilderError> {
+        Ok(DeleteFieldIndexCollection {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            wait: match self.wait {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            field_name: match self.field_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("field_name"),
+                    ));
+                }
+            },
+            ordering: match self.ordering {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            wait: core::default::Default::default(),
+            field_name: core::default::Default::default(),
+            ordering: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<DeleteFieldIndexCollectionBuilder> for DeleteFieldIndexCollection {
+    fn from(value: DeleteFieldIndexCollectionBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "DeleteFieldIndexCollectionBuilder", "DeleteFieldIndexCollection",
+        ))
+    }
+}
+
+impl DeleteFieldIndexCollectionBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> DeleteFieldIndexCollection {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "DeleteFieldIndexCollectionBuilder", "DeleteFieldIndexCollection",
+        ))
+    }
+}
+
+impl DeleteFieldIndexCollectionBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/delete_payload_points_builder.rs
+++ b/src/builders/delete_payload_points_builder.rs
@@ -1,0 +1,143 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct DeletePayloadPointsBuilder {
+    /// name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Wait until the changes have been applied?
+    pub(crate) wait: Option<Option<bool>>,
+    /// List of keys to delete
+    pub(crate) keys: Option<Vec<String>>,
+    /// Affected points
+    points_selector: Option<points_selector::PointsSelectorOneOf>,
+    /// Write ordering guarantees
+    pub(crate) ordering: Option<Option<WriteOrdering>>,
+    /// Option for custom sharding to specify used shard keys
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+}
+
+impl DeletePayloadPointsBuilder {
+    /// name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Wait until the changes have been applied?
+    #[allow(unused_mut)]
+    pub fn wait(self, value: bool) -> Self {
+        let mut new = self;
+        new.wait = Option::Some(Option::Some(value));
+        new
+    }
+    /// List of keys to delete
+    #[allow(unused_mut)]
+    pub fn keys(self, value: Vec<String>) -> Self {
+        let mut new = self;
+        new.keys = Option::Some(value);
+        new
+    }
+    /// Affected points
+    #[allow(unused_mut)]
+    pub fn points_selector<VALUE: core::convert::Into<points_selector::PointsSelectorOneOf>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.points_selector = Option::Some(value.into());
+        new
+    }
+    /// Write ordering guarantees
+    #[allow(unused_mut)]
+    pub fn ordering<VALUE: core::convert::Into<WriteOrdering>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.ordering = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Option for custom sharding to specify used shard keys
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `DeletePayloadPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<DeletePayloadPoints, DeletePayloadPointsBuilderError> {
+        Ok(DeletePayloadPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            wait: match self.wait {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            keys: match self.keys {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("keys"),
+                    ));
+                }
+            },
+            points_selector: { convert_option(&self.points_selector) },
+            ordering: match self.ordering {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            wait: core::default::Default::default(),
+            keys: core::default::Default::default(),
+            points_selector: core::default::Default::default(),
+            ordering: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<DeletePayloadPointsBuilder> for DeletePayloadPoints {
+    fn from(value: DeletePayloadPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "DeletePayloadPointsBuilder", "DeletePayloadPoints",
+        ))
+    }
+}
+
+impl DeletePayloadPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> DeletePayloadPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "DeletePayloadPointsBuilder", "DeletePayloadPoints",
+        ))
+    }
+}
+
+impl DeletePayloadPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/delete_point_vectors_builder.rs
+++ b/src/builders/delete_point_vectors_builder.rs
@@ -1,0 +1,139 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct DeletePointVectorsBuilder {
+    /// name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Wait until the changes have been applied?
+    pub(crate) wait: Option<Option<bool>>,
+    /// Affected points
+    points_selector: Option<points_selector::PointsSelectorOneOf>,
+    /// List of vector names to delete
+    pub(crate) vectors: Option<Option<VectorsSelector>>,
+    /// Write ordering guarantees
+    pub(crate) ordering: Option<Option<WriteOrdering>>,
+    /// Option for custom sharding to specify used shard keys
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+}
+
+impl DeletePointVectorsBuilder {
+    /// name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Wait until the changes have been applied?
+    #[allow(unused_mut)]
+    pub fn wait(self, value: bool) -> Self {
+        let mut new = self;
+        new.wait = Option::Some(Option::Some(value));
+        new
+    }
+    /// Affected points
+    #[allow(unused_mut)]
+    pub fn points_selector<VALUE: core::convert::Into<points_selector::PointsSelectorOneOf>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.points_selector = Option::Some(value.into());
+        new
+    }
+    /// List of vector names to delete
+    #[allow(unused_mut)]
+    pub fn vectors<VALUE: core::convert::Into<VectorsSelector>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.vectors = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Write ordering guarantees
+    #[allow(unused_mut)]
+    pub fn ordering<VALUE: core::convert::Into<WriteOrdering>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.ordering = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Option for custom sharding to specify used shard keys
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `DeletePointVectors`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<DeletePointVectors, DeletePointVectorsBuilderError> {
+        Ok(DeletePointVectors {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            wait: match self.wait {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            points_selector: { convert_option(&self.points_selector) },
+            vectors: match self.vectors {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            ordering: match self.ordering {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            wait: core::default::Default::default(),
+            points_selector: core::default::Default::default(),
+            vectors: core::default::Default::default(),
+            ordering: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<DeletePointVectorsBuilder> for DeletePointVectors {
+    fn from(value: DeletePointVectorsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "DeletePointVectorsBuilder", "DeletePointVectors",
+        ))
+    }
+}
+
+impl DeletePointVectorsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> DeletePointVectors {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "DeletePointVectorsBuilder", "DeletePointVectors",
+        ))
+    }
+}
+
+impl DeletePointVectorsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/delete_points_builder.rs
+++ b/src/builders/delete_points_builder.rs
@@ -1,0 +1,120 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct DeletePointsBuilder {
+    /// name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Wait until the changes have been applied?
+    pub(crate) wait: Option<Option<bool>>,
+    /// Affected points
+    points: Option<points_selector::PointsSelectorOneOf>,
+    /// Write ordering guarantees
+    pub(crate) ordering: Option<Option<WriteOrdering>>,
+    /// Option for custom sharding to specify used shard keys
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+}
+
+impl DeletePointsBuilder {
+    /// name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Wait until the changes have been applied?
+    #[allow(unused_mut)]
+    pub fn wait(self, value: bool) -> Self {
+        let mut new = self;
+        new.wait = Option::Some(Option::Some(value));
+        new
+    }
+    /// Affected points
+    #[allow(unused_mut)]
+    pub fn points<VALUE: core::convert::Into<points_selector::PointsSelectorOneOf>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.points = Option::Some(value.into());
+        new
+    }
+    /// Write ordering guarantees
+    #[allow(unused_mut)]
+    pub fn ordering<VALUE: core::convert::Into<WriteOrdering>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.ordering = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Option for custom sharding to specify used shard keys
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+
+    fn build_inner(self) -> Result<DeletePoints, DeletePointsBuilderError> {
+        Ok(DeletePoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            wait: match self.wait {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            points: { convert_option(&self.points) },
+            ordering: match self.ordering {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            wait: core::default::Default::default(),
+            points: core::default::Default::default(),
+            ordering: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<DeletePointsBuilder> for DeletePoints {
+    fn from(value: DeletePointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "DeletePointsBuilder", "DeletePoints",
+        ))
+    }
+}
+
+impl DeletePointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> DeletePoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "DeletePointsBuilder", "DeletePoints",
+        ))
+    }
+}
+
+impl DeletePointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/delete_shard_key_request_builder.rs
+++ b/src/builders/delete_shard_key_request_builder.rs
@@ -1,0 +1,86 @@
+use crate::qdrant::*;
+
+pub struct DeleteShardKeyRequestBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Request to delete shard key
+    pub(crate) request: Option<Option<DeleteShardKey>>,
+    /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+    pub(crate) timeout: Option<Option<u64>>,
+}
+
+impl DeleteShardKeyRequestBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `DeleteShardKeyRequest`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<DeleteShardKeyRequest, DeleteShardKeyRequestBuilderError> {
+        Ok(DeleteShardKeyRequest {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            request: match self.request {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            request: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<DeleteShardKeyRequestBuilder> for DeleteShardKeyRequest {
+    fn from(value: DeleteShardKeyRequestBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "DeleteShardKeyRequestBuilder", "DeleteShardKeyRequest",
+        ))
+    }
+}
+
+impl DeleteShardKeyRequestBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> DeleteShardKeyRequest {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "DeleteShardKeyRequestBuilder", "DeleteShardKeyRequest",
+        ))
+    }
+}
+
+impl DeleteShardKeyRequestBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/delete_snapshot_request_builder.rs
+++ b/src/builders/delete_snapshot_request_builder.rs
@@ -1,0 +1,83 @@
+use crate::qdrant::*;
+
+pub struct DeleteSnapshotRequestBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Name of the collection snapshot
+    pub(crate) snapshot_name: Option<String>,
+}
+
+impl DeleteSnapshotRequestBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Name of the collection snapshot
+    #[allow(unused_mut)]
+    pub fn snapshot_name(self, value: String) -> Self {
+        let mut new = self;
+        new.snapshot_name = Option::Some(value);
+        new
+    }
+    /**Builds a new `DeleteSnapshotRequest`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<DeleteSnapshotRequest, DeleteSnapshotRequestBuilderError> {
+        Ok(DeleteSnapshotRequest {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            snapshot_name: match self.snapshot_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("snapshot_name"),
+                    ));
+                }
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            snapshot_name: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<DeleteSnapshotRequestBuilder> for DeleteSnapshotRequest {
+    fn from(value: DeleteSnapshotRequestBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "DeleteSnapshotRequestBuilder", "DeleteSnapshotRequest",
+        ))
+    }
+}
+
+impl DeleteSnapshotRequestBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> DeleteSnapshotRequest {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "DeleteSnapshotRequestBuilder", "DeleteSnapshotRequest",
+        ))
+    }
+}
+
+impl DeleteSnapshotRequestBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/discover_batch_points_builder.rs
+++ b/src/builders/discover_batch_points_builder.rs
@@ -1,0 +1,110 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct DiscoverBatchPointsBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    pub(crate) discover_points: Option<Vec<DiscoverPoints>>,
+    /// Options for specifying read consistency guarantees
+    read_consistency: Option<read_consistency::Value>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+}
+
+impl DiscoverBatchPointsBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn discover_points(self, value: Vec<DiscoverPoints>) -> Self {
+        let mut new = self;
+        new.discover_points = Option::Some(value);
+        new
+    }
+    /// Options for specifying read consistency guarantees
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<read_consistency::Value>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(value.into());
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `DiscoverBatchPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<DiscoverBatchPoints, DiscoverBatchPointsBuilderError> {
+        Ok(DiscoverBatchPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            discover_points: match self.discover_points {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("discover_points"),
+                    ));
+                }
+            },
+            read_consistency: { convert_option(&self.read_consistency) },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            discover_points: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<DiscoverBatchPointsBuilder> for DiscoverBatchPoints {
+    fn from(value: DiscoverBatchPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "DiscoverBatchPointsBuilder", "DiscoverBatchPoints",
+        ))
+    }
+}
+
+impl DiscoverBatchPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> DiscoverBatchPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "DiscoverBatchPointsBuilder", "DiscoverBatchPoints",
+        ))
+    }
+}
+
+impl DiscoverBatchPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/discover_input_builder.rs
+++ b/src/builders/discover_input_builder.rs
@@ -1,0 +1,75 @@
+use crate::qdrant::*;
+
+pub struct DiscoverInputBuilder {
+    /// Use this as the primary search objective
+    pub(crate) target: Option<Option<VectorInput>>,
+    /// Search space will be constrained by these pairs of vectors
+    pub(crate) context: Option<Option<ContextInput>>,
+}
+
+impl DiscoverInputBuilder {
+    /// Use this as the primary search objective
+    #[allow(unused_mut)]
+    pub fn target<VALUE: core::convert::Into<VectorInput>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.target = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Search space will be constrained by these pairs of vectors
+    #[allow(unused_mut)]
+    pub fn context<VALUE: core::convert::Into<ContextInput>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.context = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `DiscoverInput`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<DiscoverInput, DiscoverInputBuilderError> {
+        Ok(DiscoverInput {
+            target: match self.target {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            context: match self.context {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            target: core::default::Default::default(),
+            context: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<DiscoverInputBuilder> for DiscoverInput {
+    fn from(value: DiscoverInputBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "DiscoverInputBuilder", "DiscoverInput",
+        ))
+    }
+}
+
+impl DiscoverInputBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> DiscoverInput {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "DiscoverInputBuilder", "DiscoverInput",
+        ))
+    }
+}
+
+impl DiscoverInputBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/discover_points_builder.rs
+++ b/src/builders/discover_points_builder.rs
@@ -1,0 +1,259 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct DiscoverPointsBuilder {
+    /// name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Use this as the primary search objective
+    pub(crate) target: Option<Option<TargetVector>>,
+    /// Search will be constrained by these pairs of examples
+    pub(crate) context: Option<Vec<ContextExamplePair>>,
+    /// Filter conditions - return only those points that satisfy the specified conditions
+    pub(crate) filter: Option<Option<Filter>>,
+    /// Max number of result
+    pub(crate) limit: Option<u64>,
+    /// Options for specifying which payload to include or not
+    with_payload: Option<with_payload_selector::SelectorOptions>,
+    /// Search config
+    pub(crate) params: Option<Option<SearchParams>>,
+    /// Offset of the result
+    pub(crate) offset: Option<Option<u64>>,
+    /// Define which vector to use for recommendation, if not specified - default vector
+    pub(crate) using: Option<Option<String>>,
+    /// Options for specifying which vectors to include into response
+    with_vectors: Option<with_vectors_selector::SelectorOptions>,
+    /// Name of the collection to use for points lookup, if not specified - use current collection
+    pub(crate) lookup_from: Option<Option<LookupLocation>>,
+    /// Options for specifying read consistency guarantees
+    read_consistency: Option<read_consistency::Value>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+}
+
+impl DiscoverPointsBuilder {
+    /// name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Use this as the primary search objective
+    #[allow(unused_mut)]
+    pub fn target<VALUE: core::convert::Into<TargetVector>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.target = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Search will be constrained by these pairs of examples
+    #[allow(unused_mut)]
+    pub fn context(self, value: Vec<ContextExamplePair>) -> Self {
+        let mut new = self;
+        new.context = Option::Some(value);
+        new
+    }
+    /// Filter conditions - return only those points that satisfy the specified conditions
+    #[allow(unused_mut)]
+    pub fn filter<VALUE: core::convert::Into<Filter>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.filter = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Max number of result
+    #[allow(unused_mut)]
+    pub fn limit(self, value: u64) -> Self {
+        let mut new = self;
+        new.limit = Option::Some(value);
+        new
+    }
+    /// Options for specifying which payload to include or not
+    #[allow(unused_mut)]
+    pub fn with_payload<VALUE: core::convert::Into<with_payload_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_payload = Option::Some(value.into());
+        new
+    }
+    /// Search config
+    #[allow(unused_mut)]
+    pub fn params<VALUE: core::convert::Into<SearchParams>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.params = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Offset of the result
+    #[allow(unused_mut)]
+    pub fn offset(self, value: u64) -> Self {
+        let mut new = self;
+        new.offset = Option::Some(Option::Some(value));
+        new
+    }
+    /// Define which vector to use for recommendation, if not specified - default vector
+    #[allow(unused_mut)]
+    pub fn using<VALUE: core::convert::Into<String>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.using = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Options for specifying which vectors to include into response
+    #[allow(unused_mut)]
+    pub fn with_vectors<VALUE: core::convert::Into<with_vectors_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_vectors = Option::Some(value.into());
+        new
+    }
+    /// Name of the collection to use for points lookup, if not specified - use current collection
+    #[allow(unused_mut)]
+    pub fn lookup_from<VALUE: core::convert::Into<LookupLocation>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.lookup_from = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Options for specifying read consistency guarantees
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<read_consistency::Value>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(value.into());
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `DiscoverPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<DiscoverPoints, DiscoverPointsBuilderError> {
+        Ok(DiscoverPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            target: match self.target {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            context: match self.context {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("context"),
+                    ));
+                }
+            },
+            filter: match self.filter {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            limit: match self.limit {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("limit"),
+                    ));
+                }
+            },
+            with_payload: { convert_option(&self.with_payload) },
+            params: match self.params {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            offset: match self.offset {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            using: match self.using {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            with_vectors: { convert_option(&self.with_vectors) },
+            lookup_from: match self.lookup_from {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            read_consistency: { convert_option(&self.read_consistency) },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            target: core::default::Default::default(),
+            context: core::default::Default::default(),
+            filter: core::default::Default::default(),
+            limit: core::default::Default::default(),
+            with_payload: core::default::Default::default(),
+            params: core::default::Default::default(),
+            offset: core::default::Default::default(),
+            using: core::default::Default::default(),
+            with_vectors: core::default::Default::default(),
+            lookup_from: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<DiscoverPointsBuilder> for DiscoverPoints {
+    fn from(value: DiscoverPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "DiscoverPointsBuilder", "DiscoverPoints",
+        ))
+    }
+}
+
+impl DiscoverPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> DiscoverPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "DiscoverPointsBuilder", "DiscoverPoints",
+        ))
+    }
+}
+
+impl DiscoverPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/facet_counts_builder.rs
+++ b/src/builders/facet_counts_builder.rs
@@ -1,0 +1,173 @@
+use crate::qdrant::*;
+
+pub struct FacetCountsBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Payload key of the facet
+    pub(crate) key: Option<String>,
+    /// Filter conditions - return only those points that satisfy the specified conditions.
+    pub(crate) filter: Option<Option<Filter>>,
+    /// Max number of facets. Default is 10.
+    pub(crate) limit: Option<Option<u64>>,
+    /// If true, return exact counts, slower but useful for debugging purposes. Default is false.
+    pub(crate) exact: Option<Option<bool>>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+    /// Options for specifying read consistency guarantees
+    pub(crate) read_consistency: Option<Option<ReadConsistency>>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+}
+
+impl FacetCountsBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Payload key of the facet
+    #[allow(unused_mut)]
+    pub fn key(self, value: String) -> Self {
+        let mut new = self;
+        new.key = Option::Some(value);
+        new
+    }
+    /// Filter conditions - return only those points that satisfy the specified conditions.
+    #[allow(unused_mut)]
+    pub fn filter<VALUE: core::convert::Into<Filter>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.filter = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Max number of facets. Default is 10.
+    #[allow(unused_mut)]
+    pub fn limit(self, value: u64) -> Self {
+        let mut new = self;
+        new.limit = Option::Some(Option::Some(value));
+        new
+    }
+    /// If true, return exact counts, slower but useful for debugging purposes. Default is false.
+    #[allow(unused_mut)]
+    pub fn exact(self, value: bool) -> Self {
+        let mut new = self;
+        new.exact = Option::Some(Option::Some(value));
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /// Options for specifying read consistency guarantees
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<ReadConsistency>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `FacetCounts`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<FacetCounts, FacetCountsBuilderError> {
+        Ok(FacetCounts {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            key: match self.key {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("key"),
+                    ));
+                }
+            },
+            filter: match self.filter {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            limit: match self.limit {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            exact: match self.exact {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            read_consistency: match self.read_consistency {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            key: core::default::Default::default(),
+            filter: core::default::Default::default(),
+            limit: core::default::Default::default(),
+            exact: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<FacetCountsBuilder> for FacetCounts {
+    fn from(value: FacetCountsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "FacetCountsBuilder", "FacetCounts",
+        ))
+    }
+}
+
+impl FacetCountsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> FacetCounts {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "FacetCountsBuilder", "FacetCounts",
+        ))
+    }
+}
+
+impl FacetCountsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/float_index_params_builder.rs
+++ b/src/builders/float_index_params_builder.rs
@@ -1,0 +1,69 @@
+use crate::qdrant::*;
+
+pub struct FloatIndexParamsBuilder {
+    /// If true - store index on disk.
+    pub(crate) on_disk: Option<Option<bool>>,
+    /// If true - use this key to organize storage of the collection data. This option assumes that this key will be used in majority of filtered requests.
+    pub(crate) is_principal: Option<Option<bool>>,
+}
+
+impl FloatIndexParamsBuilder {
+    /// If true - store index on disk.
+    #[allow(unused_mut)]
+    pub fn on_disk(self, value: bool) -> Self {
+        let mut new = self;
+        new.on_disk = Option::Some(Option::Some(value));
+        new
+    }
+    /// If true - use this key to organize storage of the collection data. This option assumes that this key will be used in majority of filtered requests.
+    #[allow(unused_mut)]
+    pub fn is_principal(self, value: bool) -> Self {
+        let mut new = self;
+        new.is_principal = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `FloatIndexParams`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<FloatIndexParams, std::convert::Infallible> {
+        Ok(FloatIndexParams {
+            on_disk: match self.on_disk {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            is_principal: match self.is_principal {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            on_disk: core::default::Default::default(),
+            is_principal: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<FloatIndexParamsBuilder> for FloatIndexParams {
+    fn from(value: FloatIndexParamsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "FloatIndexParamsBuilder", "FloatIndexParams",
+        ))
+    }
+}
+
+impl FloatIndexParamsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> FloatIndexParams {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "FloatIndexParamsBuilder", "FloatIndexParams",
+        ))
+    }
+}

--- a/src/builders/geo_index_params_builder.rs
+++ b/src/builders/geo_index_params_builder.rs
@@ -1,0 +1,55 @@
+use crate::qdrant::*;
+
+pub struct GeoIndexParamsBuilder {
+    /// If true - store index on disk.
+    pub(crate) on_disk: Option<Option<bool>>,
+}
+
+impl GeoIndexParamsBuilder {
+    /// If true - store index on disk.
+    #[allow(unused_mut)]
+    pub fn on_disk(self, value: bool) -> Self {
+        let mut new = self;
+        new.on_disk = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `GeoIndexParams`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<GeoIndexParams, std::convert::Infallible> {
+        Ok(GeoIndexParams {
+            on_disk: match self.on_disk {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            on_disk: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<GeoIndexParamsBuilder> for GeoIndexParams {
+    fn from(value: GeoIndexParamsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "GeoIndexParamsBuilder", "GeoIndexParams",
+        ))
+    }
+}
+
+impl GeoIndexParamsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> GeoIndexParams {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "GeoIndexParamsBuilder", "GeoIndexParams",
+        ))
+    }
+}

--- a/src/builders/get_points_builder.rs
+++ b/src/builders/get_points_builder.rs
@@ -1,0 +1,157 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct GetPointsBuilder {
+    /// name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// List of points to retrieve
+    pub(crate) ids: Option<Vec<PointId>>,
+    /// Options for specifying which payload to include or not
+    with_payload: Option<with_payload_selector::SelectorOptions>,
+    /// Options for specifying which vectors to include into response
+    with_vectors: Option<with_vectors_selector::SelectorOptions>,
+    /// Options for specifying read consistency guarantees
+    read_consistency: Option<read_consistency::Value>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+}
+
+impl GetPointsBuilder {
+    /// name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// List of points to retrieve
+    #[allow(unused_mut)]
+    pub fn ids(self, value: Vec<PointId>) -> Self {
+        let mut new = self;
+        new.ids = Option::Some(value);
+        new
+    }
+    /// Options for specifying which payload to include or not
+    #[allow(unused_mut)]
+    pub fn with_payload<VALUE: core::convert::Into<with_payload_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_payload = Option::Some(value.into());
+        new
+    }
+    /// Options for specifying which vectors to include into response
+    #[allow(unused_mut)]
+    pub fn with_vectors<VALUE: core::convert::Into<with_vectors_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_vectors = Option::Some(value.into());
+        new
+    }
+    /// Options for specifying read consistency guarantees
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<read_consistency::Value>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(value.into());
+        new
+    }
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `GetPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<GetPoints, GetPointsBuilderError> {
+        Ok(GetPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            ids: match self.ids {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("ids"),
+                    ));
+                }
+            },
+            with_payload: { convert_option(&self.with_payload) },
+            with_vectors: { convert_option(&self.with_vectors) },
+            read_consistency: { convert_option(&self.read_consistency) },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            ids: core::default::Default::default(),
+            with_payload: core::default::Default::default(),
+            with_vectors: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<GetPointsBuilder> for GetPoints {
+    fn from(value: GetPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "GetPointsBuilder", "GetPoints",
+        ))
+    }
+}
+
+impl GetPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> GetPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "GetPointsBuilder", "GetPoints",
+        ))
+    }
+}
+
+impl GetPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/hnsw_config_diff_builder.rs
+++ b/src/builders/hnsw_config_diff_builder.rs
@@ -1,0 +1,151 @@
+use crate::qdrant::*;
+
+pub struct HnswConfigDiffBuilder {
+    ///
+    /// Number of edges per node in the index graph. Larger the value - more accurate the search, more space required.
+    pub(crate) m: Option<Option<u64>>,
+    ///
+    /// Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build the index.
+    pub(crate) ef_construct: Option<Option<u64>>,
+    ///
+    /// Minimal size (in KiloBytes) of vectors for additional payload-based indexing.
+    /// If the payload chunk is smaller than `full_scan_threshold` additional indexing won't be used -
+    /// in this case full-scan search should be preferred by query planner and additional indexing is not required.
+    /// Note: 1 Kb = 1 vector of size 256
+    pub(crate) full_scan_threshold: Option<Option<u64>>,
+    ///
+    /// Number of parallel threads used for background index building.
+    /// If 0 - automatically select from 8 to 16.
+    /// Best to keep between 8 and 16 to prevent likelihood of building broken/inefficient HNSW graphs.
+    /// On small CPUs, less threads are used.
+    pub(crate) max_indexing_threads: Option<Option<u64>>,
+    ///
+    /// Store HNSW index on disk. If set to false, the index will be stored in RAM.
+    pub(crate) on_disk: Option<Option<bool>>,
+    ///
+    /// Number of additional payload-aware links per node in the index graph. If not set - regular M parameter will be used.
+    pub(crate) payload_m: Option<Option<u64>>,
+}
+#[allow(clippy::all)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[allow(dead_code)]
+impl HnswConfigDiffBuilder {
+    ///
+    /// Number of edges per node in the index graph. Larger the value - more accurate the search, more space required.
+    #[allow(unused_mut)]
+    pub fn m(self, value: u64) -> Self {
+        let mut new = self;
+        new.m = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build the index.
+    #[allow(unused_mut)]
+    pub fn ef_construct(self, value: u64) -> Self {
+        let mut new = self;
+        new.ef_construct = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// Minimal size (in KiloBytes) of vectors for additional payload-based indexing.
+    /// If the payload chunk is smaller than `full_scan_threshold` additional indexing won't be used -
+    /// in this case full-scan search should be preferred by query planner and additional indexing is not required.
+    /// Note: 1 Kb = 1 vector of size 256
+    #[allow(unused_mut)]
+    pub fn full_scan_threshold(self, value: u64) -> Self {
+        let mut new = self;
+        new.full_scan_threshold = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// Number of parallel threads used for background index building.
+    /// If 0 - automatically select from 8 to 16.
+    /// Best to keep between 8 and 16 to prevent likelihood of building broken/inefficient HNSW graphs.
+    /// On small CPUs, less threads are used.
+    #[allow(unused_mut)]
+    pub fn max_indexing_threads(self, value: u64) -> Self {
+        let mut new = self;
+        new.max_indexing_threads = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// Store HNSW index on disk. If set to false, the index will be stored in RAM.
+    #[allow(unused_mut)]
+    pub fn on_disk(self, value: bool) -> Self {
+        let mut new = self;
+        new.on_disk = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// Number of additional payload-aware links per node in the index graph. If not set - regular M parameter will be used.
+    #[allow(unused_mut)]
+    pub fn payload_m(self, value: u64) -> Self {
+        let mut new = self;
+        new.payload_m = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `HnswConfigDiff`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<HnswConfigDiff, std::convert::Infallible> {
+        Ok(HnswConfigDiff {
+            m: match self.m {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            ef_construct: match self.ef_construct {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            full_scan_threshold: match self.full_scan_threshold {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            max_indexing_threads: match self.max_indexing_threads {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            on_disk: match self.on_disk {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            payload_m: match self.payload_m {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            m: core::default::Default::default(),
+            ef_construct: core::default::Default::default(),
+            full_scan_threshold: core::default::Default::default(),
+            max_indexing_threads: core::default::Default::default(),
+            on_disk: core::default::Default::default(),
+            payload_m: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<HnswConfigDiffBuilder> for HnswConfigDiff {
+    fn from(value: HnswConfigDiffBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "HnswConfigDiffBuilder", "HnswConfigDiff",
+        ))
+    }
+}
+
+impl HnswConfigDiffBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> HnswConfigDiff {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "HnswConfigDiffBuilder", "HnswConfigDiff",
+        ))
+    }
+}

--- a/src/builders/integer_index_params_builder.rs
+++ b/src/builders/integer_index_params_builder.rs
@@ -1,0 +1,103 @@
+use crate::qdrant::*;
+
+pub struct IntegerIndexParamsBuilder {
+    /// If true - support direct lookups.
+    pub(crate) lookup: Option<Option<bool>>,
+    /// If true - support ranges filters.
+    pub(crate) range: Option<Option<bool>>,
+    /// If true - use this key to organize storage of the collection data. This option assumes that this key will be used in majority of filtered requests.
+    pub(crate) is_principal: Option<Option<bool>>,
+    /// If true - store index on disk.
+    pub(crate) on_disk: Option<Option<bool>>,
+}
+
+impl IntegerIndexParamsBuilder {
+    /// If true - support direct lookups.
+    #[allow(unused_mut)]
+    pub fn lookup<VALUE: core::convert::Into<bool>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.lookup = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If true - support ranges filters.
+    #[allow(unused_mut)]
+    pub fn range<VALUE: core::convert::Into<bool>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.range = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If true - use this key to organize storage of the collection data. This option assumes that this key will be used in majority of filtered requests.
+    #[allow(unused_mut)]
+    pub fn is_principal(self, value: bool) -> Self {
+        let mut new = self;
+        new.is_principal = Option::Some(Option::Some(value));
+        new
+    }
+    /// If true - store index on disk.
+    #[allow(unused_mut)]
+    pub fn on_disk(self, value: bool) -> Self {
+        let mut new = self;
+        new.on_disk = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `IntegerIndexParams`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<IntegerIndexParams, IntegerIndexParamsBuilderError> {
+        Ok(IntegerIndexParams {
+            lookup: match self.lookup {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            range: match self.range {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            is_principal: match self.is_principal {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            on_disk: match self.on_disk {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            lookup: core::default::Default::default(),
+            range: core::default::Default::default(),
+            is_principal: core::default::Default::default(),
+            on_disk: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<IntegerIndexParamsBuilder> for IntegerIndexParams {
+    fn from(value: IntegerIndexParamsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "IntegerIndexParamsBuilder", "IntegerIndexParams",
+        ))
+    }
+}
+
+impl IntegerIndexParamsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> IntegerIndexParams {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "IntegerIndexParamsBuilder", "IntegerIndexParams",
+        ))
+    }
+}
+
+impl IntegerIndexParamsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/keyword_index_params_builder.rs
+++ b/src/builders/keyword_index_params_builder.rs
@@ -1,0 +1,69 @@
+use crate::qdrant::*;
+
+pub struct KeywordIndexParamsBuilder {
+    /// If true - used for tenant optimization.
+    pub(crate) is_tenant: Option<Option<bool>>,
+    /// If true - store index on disk.
+    pub(crate) on_disk: Option<Option<bool>>,
+}
+
+impl KeywordIndexParamsBuilder {
+    /// If true - used for tenant optimization.
+    #[allow(unused_mut)]
+    pub fn is_tenant(self, value: bool) -> Self {
+        let mut new = self;
+        new.is_tenant = Option::Some(Option::Some(value));
+        new
+    }
+    /// If true - store index on disk.
+    #[allow(unused_mut)]
+    pub fn on_disk(self, value: bool) -> Self {
+        let mut new = self;
+        new.on_disk = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `KeywordIndexParams`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<KeywordIndexParams, std::convert::Infallible> {
+        Ok(KeywordIndexParams {
+            is_tenant: match self.is_tenant {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            on_disk: match self.on_disk {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            is_tenant: core::default::Default::default(),
+            on_disk: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<KeywordIndexParamsBuilder> for KeywordIndexParams {
+    fn from(value: KeywordIndexParamsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "KeywordIndexParamsBuilder", "KeywordIndexParams",
+        ))
+    }
+}
+
+impl KeywordIndexParamsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> KeywordIndexParams {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "KeywordIndexParamsBuilder", "KeywordIndexParams",
+        ))
+    }
+}

--- a/src/builders/lookup_location_builder.rs
+++ b/src/builders/lookup_location_builder.rs
@@ -1,0 +1,94 @@
+use crate::qdrant::*;
+
+pub struct LookupLocationBuilder {
+    pub(crate) collection_name: Option<String>,
+    /// Which vector to use for search, if not specified - use default vector
+    pub(crate) vector_name: Option<Option<String>>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+}
+
+impl LookupLocationBuilder {
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Which vector to use for search, if not specified - use default vector
+    #[allow(unused_mut)]
+    pub fn vector_name<VALUE: core::convert::Into<String>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.vector_name = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `LookupLocation`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<LookupLocation, LookupLocationBuilderError> {
+        Ok(LookupLocation {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            vector_name: match self.vector_name {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            vector_name: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<LookupLocationBuilder> for LookupLocation {
+    fn from(value: LookupLocationBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "LookupLocationBuilder", "LookupLocation",
+        ))
+    }
+}
+
+impl LookupLocationBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> LookupLocation {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "LookupLocationBuilder", "LookupLocation",
+        ))
+    }
+}
+
+impl LookupLocationBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/mod.rs
+++ b/src/builders/mod.rs
@@ -1,0 +1,212 @@
+//mod vector_params_builder;
+//pub use vector_params_builder::VectorParamsBuilder;
+//
+//mod vector_params_diff_builder;
+//pub use vector_params_diff_builder::VectorParamsDiffBuilder;
+//
+//mod sparse_vector_params_builder;
+//pub use sparse_vector_params_builder::SparseVectorParamsBuilder;
+//
+//mod multi_vector_config_builder;
+//pub use multi_vector_config_builder::MultiVectorConfigBuilder;
+//
+//mod hnsw_config_diff_builder;
+//pub use hnsw_config_diff_builder::HnswConfigDiffBuilder;
+//
+//mod sparse_index_config_builder;
+//pub use sparse_index_config_builder::SparseIndexConfigBuilder;
+//
+//mod wal_config_diff_builder;
+//pub use wal_config_diff_builder::WalConfigDiffBuilder;
+//
+//mod optimizers_config_diff_builder;
+//pub use optimizers_config_diff_builder::OptimizersConfigDiffBuilder;
+//
+//mod scalar_quantization_builder;
+//pub use scalar_quantization_builder::ScalarQuantizationBuilder;
+//
+//mod product_quantization_builder;
+//pub use product_quantization_builder::ProductQuantizationBuilder;
+//
+//mod binary_quantization_builder;
+//pub use binary_quantization_builder::BinaryQuantizationBuilder;
+//
+//mod strict_mode_config_builder;
+//pub use strict_mode_config_builder::StrictModeConfigBuilder;
+//
+//mod update_collection_builder;
+//pub use update_collection_builder::UpdateCollectionBuilder;
+//
+//mod delete_collection_builder;
+//pub use delete_collection_builder::DeleteCollectionBuilder;
+//
+//mod collection_params_diff_builder;
+//pub use collection_params_diff_builder::CollectionParamsDiffBuilder;
+//
+//mod keyword_index_params_builder;
+//pub use keyword_index_params_builder::KeywordIndexParamsBuilder;
+//
+//mod integer_index_params_builder;
+//pub use integer_index_params_builder::IntegerIndexParamsBuilder;
+//
+//mod float_index_params_builder;
+//pub use float_index_params_builder::FloatIndexParamsBuilder;
+//
+//mod geo_index_params_builder;
+//pub use geo_index_params_builder::GeoIndexParamsBuilder;
+//
+//mod text_index_params_builder;
+//pub use text_index_params_builder::TextIndexParamsBuilder;
+//
+//mod datetime_index_params_builder;
+//pub use datetime_index_params_builder::DatetimeIndexParamsBuilder;
+//
+//mod uuid_index_params_builder;
+//pub use uuid_index_params_builder::UuidIndexParamsBuilder;
+//
+//mod create_alias_builder;
+//pub use create_alias_builder::CreateAliasBuilder;
+//
+//mod rename_alias_builder;
+//pub use rename_alias_builder::RenameAliasBuilder;
+//
+//mod move_shard_builder;
+//pub use move_shard_builder::MoveShardBuilder;
+//
+//mod replicate_shard_builder;
+//pub use replicate_shard_builder::ReplicateShardBuilder;
+//
+//mod abort_shard_transfer_builder;
+//pub use abort_shard_transfer_builder::AbortShardTransferBuilder;
+//
+//mod replica_builder;
+//pub use replica_builder::ReplicaBuilder;
+//
+//mod create_shard_key_builder;
+//pub use create_shard_key_builder::CreateShardKeyBuilder;
+//
+//mod update_collection_cluster_setup_request_builder;
+//pub use update_collection_cluster_setup_request_builder::UpdateCollectionClusterSetupRequestBuilder;
+//
+//mod create_shard_key_request_builder;
+//pub use create_shard_key_request_builder::CreateShardKeyRequestBuilder;
+//
+//mod delete_shard_key_request_builder;
+//pub use delete_shard_key_request_builder::DeleteShardKeyRequestBuilder;
+//
+//mod upsert_points_builder;
+//pub use upsert_points_builder::UpsertPointsBuilder;
+//
+//mod delete_points_builder;
+//pub use delete_points_builder::DeletePointsBuilder;
+//
+//mod get_points_builder;
+//pub use get_points_builder::GetPointsBuilder;
+//
+//mod update_point_vectors_builder;
+//pub use update_point_vectors_builder::UpdatePointVectorsBuilder;
+//
+//mod delete_point_vectors_builder;
+//pub use delete_point_vectors_builder::DeletePointVectorsBuilder;
+//
+//mod set_payload_points_builder;
+//pub use set_payload_points_builder::SetPayloadPointsBuilder;
+//
+//mod delete_payload_points_builder;
+//pub use delete_payload_points_builder::DeletePayloadPointsBuilder;
+//
+//mod clear_payload_points_builder;
+//pub use clear_payload_points_builder::ClearPayloadPointsBuilder;
+//
+//mod create_field_index_collection_builder;
+//pub use create_field_index_collection_builder::CreateFieldIndexCollectionBuilder;
+//
+//mod delete_field_index_collection_builder;
+//pub use delete_field_index_collection_builder::DeleteFieldIndexCollectionBuilder;
+//
+//mod quantization_search_params_builder;
+//pub use quantization_search_params_builder::QuantizationSearchParamsBuilder;
+//
+//mod search_params_builder;
+//pub use search_params_builder::SearchParamsBuilder;
+//
+//mod search_points_builder;
+//pub use search_points_builder::SearchPointsBuilder;
+//
+//mod search_batch_points_builder;
+//pub use search_batch_points_builder::SearchBatchPointsBuilder;
+//
+//mod with_lookup_builder;
+//pub use with_lookup_builder::WithLookupBuilder;
+//
+//mod search_point_groups_builder;
+//pub use search_point_groups_builder::SearchPointGroupsBuilder;
+//
+//mod order_by_builder;
+//pub use order_by_builder::OrderByBuilder;
+//
+//mod scroll_points_builder;
+//pub use scroll_points_builder::ScrollPointsBuilder;
+//
+//mod lookup_location_builder;
+//pub use lookup_location_builder::LookupLocationBuilder;
+//
+//mod recommend_points_builder;
+//pub use recommend_points_builder::RecommendPointsBuilder;
+//
+//mod recommend_batch_points_builder;
+//pub use recommend_batch_points_builder::RecommendBatchPointsBuilder;
+//
+//mod recommend_point_groups_builder;
+//pub use recommend_point_groups_builder::RecommendPointGroupsBuilder;
+//
+//mod context_example_pair_builder;
+//pub use context_example_pair_builder::ContextExamplePairBuilder;
+//
+//mod discover_points_builder;
+//pub use discover_points_builder::DiscoverPointsBuilder;
+//
+//mod discover_batch_points_builder;
+//pub use discover_batch_points_builder::DiscoverBatchPointsBuilder;
+//
+//mod count_points_builder;
+//pub use count_points_builder::CountPointsBuilder;
+//
+//mod recommend_input_builder;
+//pub use recommend_input_builder::RecommendInputBuilder;
+//
+//mod context_input_pair_builder;
+//pub use context_input_pair_builder::ContextInputPairBuilder;
+//
+//mod discover_input_builder;
+//pub use discover_input_builder::DiscoverInputBuilder;
+//
+//mod context_input_builder;
+//pub use context_input_builder::ContextInputBuilder;
+//
+//mod prefetch_query_builder;
+//pub use prefetch_query_builder::PrefetchQueryBuilder;
+//
+//mod query_points_builder;
+//pub use query_points_builder::QueryPointsBuilder;
+//
+//mod query_batch_points_builder;
+//pub use query_batch_points_builder::QueryBatchPointsBuilder;
+//
+//mod query_point_groups_builder;
+//pub use query_point_groups_builder::QueryPointGroupsBuilder;
+//
+//mod facet_counts_builder;
+//pub use facet_counts_builder::FacetCountsBuilder;
+//
+//mod search_matrix_points_builder;
+//pub use search_matrix_points_builder::SearchMatrixPointsBuilder;
+//
+//mod update_batch_points_builder;
+//pub use update_batch_points_builder::UpdateBatchPointsBuilder;
+//
+//mod delete_snapshot_request_builder;
+//pub use delete_snapshot_request_builder::DeleteSnapshotRequestBuilder;
+
+pub mod create_collection_builder;
+pub use create_collection_builder::CreateCollectionBuilder;

--- a/src/builders/move_shard_builder.rs
+++ b/src/builders/move_shard_builder.rs
@@ -1,0 +1,121 @@
+use crate::qdrant::*;
+
+pub struct MoveShardBuilder {
+    /// Local shard id
+    pub(crate) shard_id: Option<u32>,
+    pub(crate) to_shard_id: Option<Option<u32>>,
+    pub(crate) from_peer_id: Option<u64>,
+    pub(crate) to_peer_id: Option<u64>,
+    pub(crate) method: Option<Option<i32>>,
+}
+
+impl MoveShardBuilder {
+    /// Local shard id
+    #[allow(unused_mut)]
+    pub fn shard_id(self, value: u32) -> Self {
+        let mut new = self;
+        new.shard_id = Option::Some(value);
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn to_shard_id(self, value: u32) -> Self {
+        let mut new = self;
+        new.to_shard_id = Option::Some(Option::Some(value));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn from_peer_id(self, value: u64) -> Self {
+        let mut new = self;
+        new.from_peer_id = Option::Some(value);
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn to_peer_id(self, value: u64) -> Self {
+        let mut new = self;
+        new.to_peer_id = Option::Some(value);
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn method<VALUE: core::convert::Into<i32>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.method = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `MoveShard`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<MoveShard, MoveShardBuilderError> {
+        Ok(MoveShard {
+            shard_id: match self.shard_id {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("shard_id"),
+                    ));
+                }
+            },
+            to_shard_id: match self.to_shard_id {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            from_peer_id: match self.from_peer_id {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("from_peer_id"),
+                    ));
+                }
+            },
+            to_peer_id: match self.to_peer_id {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("to_peer_id"),
+                    ));
+                }
+            },
+            method: match self.method {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            shard_id: core::default::Default::default(),
+            to_shard_id: core::default::Default::default(),
+            from_peer_id: core::default::Default::default(),
+            to_peer_id: core::default::Default::default(),
+            method: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<MoveShardBuilder> for MoveShard {
+    fn from(value: MoveShardBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "MoveShardBuilder", "MoveShard",
+        ))
+    }
+}
+
+impl MoveShardBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> MoveShard {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "MoveShardBuilder", "MoveShard",
+        ))
+    }
+}
+
+impl MoveShardBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/multi_vector_config_builder.rs
+++ b/src/builders/multi_vector_config_builder.rs
@@ -1,0 +1,61 @@
+use crate::qdrant::*;
+
+pub struct MultiVectorConfigBuilder {
+    /// Comparator for multi-vector search
+    pub(crate) comparator: Option<i32>,
+}
+
+impl MultiVectorConfigBuilder {
+    /// Comparator for multi-vector search
+    #[allow(unused_mut)]
+    pub fn comparator<VALUE: core::convert::Into<i32>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.comparator = Option::Some(value.into());
+        new
+    }
+    /**Builds a new `MultiVectorConfig`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<MultiVectorConfig, MultiVectorConfigBuilderError> {
+        Ok(MultiVectorConfig {
+            comparator: match self.comparator {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            comparator: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<MultiVectorConfigBuilder> for MultiVectorConfig {
+    fn from(value: MultiVectorConfigBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "MultiVectorConfigBuilder", "MultiVectorConfig",
+        ))
+    }
+}
+
+impl MultiVectorConfigBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> MultiVectorConfig {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "MultiVectorConfigBuilder", "MultiVectorConfig",
+        ))
+    }
+}
+
+impl MultiVectorConfigBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/optimizers_config_diff_builder.rs
+++ b/src/builders/optimizers_config_diff_builder.rs
@@ -1,0 +1,229 @@
+use crate::qdrant::*;
+
+pub struct OptimizersConfigDiffBuilder {
+    ///
+    /// The minimal fraction of deleted vectors in a segment, required to perform segment optimization
+    pub(crate) deleted_threshold: Option<Option<f64>>,
+    ///
+    /// The minimal number of vectors in a segment, required to perform segment optimization
+    pub(crate) vacuum_min_vector_number: Option<Option<u64>>,
+    ///
+    /// Target amount of segments the optimizer will try to keep.
+    /// Real amount of segments may vary depending on multiple parameters:
+    ///
+    /// - Amount of stored points.
+    /// - Current write RPS.
+    ///
+    /// It is recommended to select the default number of segments as a factor of the number of search threads,
+    /// so that each segment would be handled evenly by one of the threads.
+    pub(crate) default_segment_number: Option<Option<u64>>,
+    ///
+    /// Do not create segments larger this size (in kilobytes).
+    /// Large segments might require disproportionately long indexation times,
+    /// therefore it makes sense to limit the size of segments.
+    ///
+    /// If indexing speed is more important - make this parameter lower.
+    /// If search speed is more important - make this parameter higher.
+    /// Note: 1Kb = 1 vector of size 256
+    /// If not set, will be automatically selected considering the number of available CPUs.
+    pub(crate) max_segment_size: Option<Option<u64>>,
+    ///
+    /// Maximum size (in kilobytes) of vectors to store in-memory per segment.
+    /// Segments larger than this threshold will be stored as read-only memmaped file.
+    ///
+    /// Memmap storage is disabled by default, to enable it, set this threshold to a reasonable value.
+    ///
+    /// To disable memmap storage, set this to `0`.
+    ///
+    /// Note: 1Kb = 1 vector of size 256
+    pub(crate) memmap_threshold: Option<Option<u64>>,
+    ///
+    /// Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing
+    ///
+    /// Default value is 20,000, based on <<https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.>
+    ///
+    /// To disable vector indexing, set to `0`.
+    ///
+    /// Note: 1kB = 1 vector of size 256.
+    pub(crate) indexing_threshold: Option<Option<u64>>,
+    ///
+    /// Interval between forced flushes.
+    pub(crate) flush_interval_sec: Option<Option<u64>>,
+    ///
+    /// Max number of threads (jobs) for running optimizations per shard.
+    /// Note: each optimization job will also use `max_indexing_threads` threads by itself for index building.
+    /// If null - have no limit and choose dynamically to saturate CPU.
+    /// If 0 - no optimization threads, optimizations will be disabled.
+    pub(crate) max_optimization_threads: Option<Option<u64>>,
+}
+
+impl OptimizersConfigDiffBuilder {
+    ///
+    /// The minimal fraction of deleted vectors in a segment, required to perform segment optimization
+    #[allow(unused_mut)]
+    pub fn deleted_threshold(self, value: f64) -> Self {
+        let mut new = self;
+        new.deleted_threshold = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// The minimal number of vectors in a segment, required to perform segment optimization
+    #[allow(unused_mut)]
+    pub fn vacuum_min_vector_number(self, value: u64) -> Self {
+        let mut new = self;
+        new.vacuum_min_vector_number = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// Target amount of segments the optimizer will try to keep.
+    /// Real amount of segments may vary depending on multiple parameters:
+    ///
+    /// - Amount of stored points.
+    /// - Current write RPS.
+    ///
+    /// It is recommended to select the default number of segments as a factor of the number of search threads,
+    /// so that each segment would be handled evenly by one of the threads.
+    #[allow(unused_mut)]
+    pub fn default_segment_number(self, value: u64) -> Self {
+        let mut new = self;
+        new.default_segment_number = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// Do not create segments larger this size (in kilobytes).
+    /// Large segments might require disproportionately long indexation times,
+    /// therefore it makes sense to limit the size of segments.
+    ///
+    /// If indexing speed is more important - make this parameter lower.
+    /// If search speed is more important - make this parameter higher.
+    /// Note: 1Kb = 1 vector of size 256
+    /// If not set, will be automatically selected considering the number of available CPUs.
+    #[allow(unused_mut)]
+    pub fn max_segment_size(self, value: u64) -> Self {
+        let mut new = self;
+        new.max_segment_size = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// Maximum size (in kilobytes) of vectors to store in-memory per segment.
+    /// Segments larger than this threshold will be stored as read-only memmaped file.
+    ///
+    /// Memmap storage is disabled by default, to enable it, set this threshold to a reasonable value.
+    ///
+    /// To disable memmap storage, set this to `0`.
+    ///
+    /// Note: 1Kb = 1 vector of size 256
+    #[allow(unused_mut)]
+    pub fn memmap_threshold(self, value: u64) -> Self {
+        let mut new = self;
+        new.memmap_threshold = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing
+    ///
+    /// Default value is 20,000, based on <<https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.>
+    ///
+    /// To disable vector indexing, set to `0`.
+    ///
+    /// Note: 1kB = 1 vector of size 256.
+    #[allow(unused_mut)]
+    pub fn indexing_threshold(self, value: u64) -> Self {
+        let mut new = self;
+        new.indexing_threshold = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// Interval between forced flushes.
+    #[allow(unused_mut)]
+    pub fn flush_interval_sec(self, value: u64) -> Self {
+        let mut new = self;
+        new.flush_interval_sec = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// Max number of threads (jobs) for running optimizations per shard.
+    /// Note: each optimization job will also use `max_indexing_threads` threads by itself for index building.
+    /// If null - have no limit and choose dynamically to saturate CPU.
+    /// If 0 - no optimization threads, optimizations will be disabled.
+    #[allow(unused_mut)]
+    pub fn max_optimization_threads(self, value: u64) -> Self {
+        let mut new = self;
+        new.max_optimization_threads = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `OptimizersConfigDiff`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<OptimizersConfigDiff, std::convert::Infallible> {
+        Ok(OptimizersConfigDiff {
+            deleted_threshold: match self.deleted_threshold {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            vacuum_min_vector_number: match self.vacuum_min_vector_number {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            default_segment_number: match self.default_segment_number {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            max_segment_size: match self.max_segment_size {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            memmap_threshold: match self.memmap_threshold {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            indexing_threshold: match self.indexing_threshold {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            flush_interval_sec: match self.flush_interval_sec {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            max_optimization_threads: match self.max_optimization_threads {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            deleted_threshold: core::default::Default::default(),
+            vacuum_min_vector_number: core::default::Default::default(),
+            default_segment_number: core::default::Default::default(),
+            max_segment_size: core::default::Default::default(),
+            memmap_threshold: core::default::Default::default(),
+            indexing_threshold: core::default::Default::default(),
+            flush_interval_sec: core::default::Default::default(),
+            max_optimization_threads: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<OptimizersConfigDiffBuilder> for OptimizersConfigDiff {
+    fn from(value: OptimizersConfigDiffBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "OptimizersConfigDiffBuilder", "OptimizersConfigDiff",
+        ))
+    }
+}
+
+impl OptimizersConfigDiffBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> OptimizersConfigDiff {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "OptimizersConfigDiffBuilder", "OptimizersConfigDiff",
+        ))
+    }
+}

--- a/src/builders/order_by_builder.rs
+++ b/src/builders/order_by_builder.rs
@@ -1,0 +1,91 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct OrderByBuilder {
+    /// Payload key to order by
+    pub(crate) key: Option<String>,
+    /// Ascending or descending order
+    pub(crate) direction: Option<Option<i32>>,
+    /// Start from this value
+    start_from: Option<start_from::Value>,
+}
+
+impl OrderByBuilder {
+    /// Payload key to order by
+    #[allow(unused_mut)]
+    pub fn key(self, value: String) -> Self {
+        let mut new = self;
+        new.key = Option::Some(value);
+        new
+    }
+    /// Ascending or descending order
+    #[allow(unused_mut)]
+    pub fn direction(self, value: i32) -> Self {
+        let mut new = self;
+        new.direction = Option::Some(Option::Some(value));
+        new
+    }
+    /// Start from this value
+    #[allow(unused_mut)]
+    pub fn start_from<VALUE: core::convert::Into<start_from::Value>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.start_from = Option::Some(value.into());
+        new
+    }
+    /**Builds a new `OrderBy`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<OrderBy, OrderByBuilderError> {
+        Ok(OrderBy {
+            key: match self.key {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("key"),
+                    ));
+                }
+            },
+            direction: match self.direction {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            start_from: { convert_option(&self.start_from) },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            key: core::default::Default::default(),
+            direction: core::default::Default::default(),
+            start_from: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<OrderByBuilder> for OrderBy {
+    fn from(value: OrderByBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "OrderByBuilder", "OrderBy",
+        ))
+    }
+}
+
+impl OrderByBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> OrderBy {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "OrderByBuilder", "OrderBy",
+        ))
+    }
+}
+
+impl OrderByBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/prefetch_query_builder.rs
+++ b/src/builders/prefetch_query_builder.rs
@@ -1,0 +1,153 @@
+use crate::qdrant::*;
+
+pub struct PrefetchQueryBuilder {
+    /// Sub-requests to perform first. If present, the query will be performed on the results of the prefetches.
+    pub(crate) prefetch: Option<Vec<PrefetchQuery>>,
+    /// Query to perform. If missing, returns points ordered by their IDs.
+    pub(crate) query: Option<Option<Query>>,
+    /// Define which vector to use for querying. If missing, the default vector is is used.
+    pub(crate) using: Option<Option<String>>,
+    /// Filter conditions - return only those points that satisfy the specified conditions.
+    pub(crate) filter: Option<Option<Filter>>,
+    /// Search params for when there is no prefetch.
+    pub(crate) params: Option<Option<SearchParams>>,
+    /// Return points with scores better than this threshold.
+    pub(crate) score_threshold: Option<Option<f32>>,
+    /// Max number of points. Default is 10
+    pub(crate) limit: Option<Option<u64>>,
+    /// The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector
+    pub(crate) lookup_from: Option<Option<LookupLocation>>,
+}
+
+impl PrefetchQueryBuilder {
+    /// Sub-requests to perform first. If present, the query will be performed on the results of the prefetches.
+    #[allow(unused_mut)]
+    pub fn prefetch<VALUE: core::convert::Into<Vec<PrefetchQuery>>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.prefetch = Option::Some(value.into());
+        new
+    }
+    /// Query to perform. If missing, returns points ordered by their IDs.
+    #[allow(unused_mut)]
+    pub fn query<VALUE: core::convert::Into<Query>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.query = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Define which vector to use for querying. If missing, the default vector is is used.
+    #[allow(unused_mut)]
+    pub fn using<VALUE: core::convert::Into<String>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.using = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Filter conditions - return only those points that satisfy the specified conditions.
+    #[allow(unused_mut)]
+    pub fn filter<VALUE: core::convert::Into<Filter>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.filter = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Search params for when there is no prefetch.
+    #[allow(unused_mut)]
+    pub fn params<VALUE: core::convert::Into<SearchParams>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.params = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Return points with scores better than this threshold.
+    #[allow(unused_mut)]
+    pub fn score_threshold<VALUE: core::convert::Into<f32>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.score_threshold = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Max number of points. Default is 10
+    #[allow(unused_mut)]
+    pub fn limit<VALUE: core::convert::Into<u64>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.limit = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector
+    #[allow(unused_mut)]
+    pub fn lookup_from<VALUE: core::convert::Into<LookupLocation>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.lookup_from = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `PrefetchQuery`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<PrefetchQuery, std::convert::Infallible> {
+        Ok(PrefetchQuery {
+            prefetch: match self.prefetch {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            query: match self.query {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            using: match self.using {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            filter: match self.filter {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            params: match self.params {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            score_threshold: match self.score_threshold {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            limit: match self.limit {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            lookup_from: match self.lookup_from {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            prefetch: core::default::Default::default(),
+            query: core::default::Default::default(),
+            using: core::default::Default::default(),
+            filter: core::default::Default::default(),
+            params: core::default::Default::default(),
+            score_threshold: core::default::Default::default(),
+            limit: core::default::Default::default(),
+            lookup_from: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<PrefetchQueryBuilder> for PrefetchQuery {
+    fn from(value: PrefetchQueryBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "PrefetchQueryBuilder", "PrefetchQuery",
+        ))
+    }
+}
+
+impl PrefetchQueryBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> PrefetchQuery {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "PrefetchQueryBuilder", "PrefetchQuery",
+        ))
+    }
+}

--- a/src/builders/product_quantization_builder.rs
+++ b/src/builders/product_quantization_builder.rs
@@ -1,0 +1,79 @@
+use crate::qdrant::*;
+
+pub struct ProductQuantizationBuilder {
+    /// Compression ratio
+    pub(crate) compression: Option<i32>,
+    /// If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
+    pub(crate) always_ram: Option<Option<bool>>,
+}
+
+impl ProductQuantizationBuilder {
+    /// Compression ratio
+    #[allow(unused_mut)]
+    pub fn compression(self, value: i32) -> Self {
+        let mut new = self;
+        new.compression = Option::Some(value);
+        new
+    }
+    /// If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
+    #[allow(unused_mut)]
+    pub fn always_ram(self, value: bool) -> Self {
+        let mut new = self;
+        new.always_ram = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `ProductQuantization`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<ProductQuantization, ProductQuantizationBuilderError> {
+        Ok(ProductQuantization {
+            compression: match self.compression {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("compression"),
+                    ));
+                }
+            },
+            always_ram: match self.always_ram {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            compression: core::default::Default::default(),
+            always_ram: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<ProductQuantizationBuilder> for ProductQuantization {
+    fn from(value: ProductQuantizationBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "ProductQuantizationBuilder", "ProductQuantization",
+        ))
+    }
+}
+
+impl ProductQuantizationBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> ProductQuantization {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "ProductQuantizationBuilder", "ProductQuantization",
+        ))
+    }
+}
+
+impl ProductQuantizationBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/quantization_search_params_builder.rs
+++ b/src/builders/quantization_search_params_builder.rs
@@ -1,0 +1,101 @@
+use crate::qdrant::*;
+
+pub struct QuantizationSearchParamsBuilder {
+    ///
+    /// If set to true, search will ignore quantized vector data
+    pub(crate) ignore: Option<Option<bool>>,
+    ///
+    /// If true, use original vectors to re-score top-k results. If ignored, qdrant decides automatically does rescore enabled or not.
+    pub(crate) rescore: Option<Option<bool>>,
+    ///
+    /// Oversampling factor for quantization.
+    ///
+    /// Defines how many extra vectors should be pre-selected using quantized index,
+    /// and then re-scored using original vectors.
+    ///
+    /// For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will be pre-selected using quantized index,
+    /// and then top-100 will be returned after re-scoring.
+    pub(crate) oversampling: Option<Option<f64>>,
+}
+
+impl QuantizationSearchParamsBuilder {
+    ///
+    /// If set to true, search will ignore quantized vector data
+    #[allow(unused_mut)]
+    pub fn ignore(self, value: bool) -> Self {
+        let mut new = self;
+        new.ignore = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// If true, use original vectors to re-score top-k results. If ignored, qdrant decides automatically does rescore enabled or not.
+    #[allow(unused_mut)]
+    pub fn rescore(self, value: bool) -> Self {
+        let mut new = self;
+        new.rescore = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// Oversampling factor for quantization.
+    ///
+    /// Defines how many extra vectors should be pre-selected using quantized index,
+    /// and then re-scored using original vectors.
+    ///
+    /// For example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will be pre-selected using quantized index,
+    /// and then top-100 will be returned after re-scoring.
+    #[allow(unused_mut)]
+    pub fn oversampling(self, value: f64) -> Self {
+        let mut new = self;
+        new.oversampling = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `QuantizationSearchParams`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<QuantizationSearchParams, std::convert::Infallible> {
+        Ok(QuantizationSearchParams {
+            ignore: match self.ignore {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            rescore: match self.rescore {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            oversampling: match self.oversampling {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            ignore: core::default::Default::default(),
+            rescore: core::default::Default::default(),
+            oversampling: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<QuantizationSearchParamsBuilder> for QuantizationSearchParams {
+    fn from(value: QuantizationSearchParamsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "QuantizationSearchParamsBuilder", "QuantizationSearchParams",
+        ))
+    }
+}
+
+impl QuantizationSearchParamsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> QuantizationSearchParams {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "QuantizationSearchParamsBuilder", "QuantizationSearchParams",
+        ))
+    }
+}

--- a/src/builders/query_batch_points_builder.rs
+++ b/src/builders/query_batch_points_builder.rs
@@ -1,0 +1,108 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct QueryBatchPointsBuilder {
+    pub(crate) collection_name: Option<String>,
+    pub(crate) query_points: Option<Vec<QueryPoints>>,
+    /// Options for specifying read consistency guarantees
+    read_consistency: Option<read_consistency::Value>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+}
+
+impl QueryBatchPointsBuilder {
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn query_points(self, value: Vec<QueryPoints>) -> Self {
+        let mut new = self;
+        new.query_points = Option::Some(value);
+        new
+    }
+    /// Options for specifying read consistency guarantees
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<read_consistency::Value>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(value.into());
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `QueryBatchPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<QueryBatchPoints, QueryBatchPointsBuilderError> {
+        Ok(QueryBatchPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            query_points: match self.query_points {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("query_points"),
+                    ));
+                }
+            },
+            read_consistency: { convert_option(&self.read_consistency) },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            query_points: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<QueryBatchPointsBuilder> for QueryBatchPoints {
+    fn from(value: QueryBatchPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "QueryBatchPointsBuilder", "QueryBatchPoints",
+        ))
+    }
+}
+
+impl QueryBatchPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> QueryBatchPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "QueryBatchPointsBuilder", "QueryBatchPoints",
+        ))
+    }
+}
+
+impl QueryBatchPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/query_point_groups_builder.rs
+++ b/src/builders/query_point_groups_builder.rs
@@ -1,0 +1,305 @@
+use crate::qdrant::*;
+
+pub struct QueryPointGroupsBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Sub-requests to perform first. If present, the query will be performed on the results of the prefetches.
+    pub(crate) prefetch: Option<Vec<PrefetchQuery>>,
+    /// Query to perform. If missing, returns points ordered by their IDs.
+    pub(crate) query: Option<Option<Query>>,
+    /// Define which vector to use for querying. If missing, the default vector is used.
+    pub(crate) using: Option<Option<String>>,
+    /// Filter conditions - return only those points that satisfy the specified conditions.
+    pub(crate) filter: Option<Option<Filter>>,
+    /// Search params for when there is no prefetch.
+    pub(crate) params: Option<Option<SearchParams>>,
+    /// Return points with scores better than this threshold.
+    pub(crate) score_threshold: Option<Option<f32>>,
+    /// Options for specifying which payload to include or not
+    pub(crate) with_payload: Option<Option<WithPayloadSelector>>,
+    /// Options for specifying which vectors to include into response
+    pub(crate) with_vectors: Option<Option<WithVectorsSelector>>,
+    /// The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector
+    pub(crate) lookup_from: Option<Option<LookupLocation>>,
+    /// Max number of points. Default is 3.
+    pub(crate) limit: Option<Option<u64>>,
+    /// Maximum amount of points to return per group. Default to 10.
+    pub(crate) group_size: Option<Option<u64>>,
+    /// Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
+    pub(crate) group_by: Option<String>,
+    /// Options for specifying read consistency guarantees
+    pub(crate) read_consistency: Option<Option<ReadConsistency>>,
+    /// Options for specifying how to use the group id to lookup points in another collection
+    pub(crate) with_lookup: Option<Option<WithLookup>>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+}
+
+impl QueryPointGroupsBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Sub-requests to perform first. If present, the query will be performed on the results of the prefetches.
+    #[allow(unused_mut)]
+    pub fn prefetch<VALUE: core::convert::Into<Vec<PrefetchQuery>>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.prefetch = Option::Some(value.into());
+        new
+    }
+    /// Query to perform. If missing, returns points ordered by their IDs.
+    #[allow(unused_mut)]
+    pub fn query<VALUE: core::convert::Into<Query>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.query = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Define which vector to use for querying. If missing, the default vector is used.
+    #[allow(unused_mut)]
+    pub fn using<VALUE: core::convert::Into<String>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.using = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Filter conditions - return only those points that satisfy the specified conditions.
+    #[allow(unused_mut)]
+    pub fn filter<VALUE: core::convert::Into<Filter>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.filter = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Search params for when there is no prefetch.
+    #[allow(unused_mut)]
+    pub fn params<VALUE: core::convert::Into<SearchParams>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.params = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Return points with scores better than this threshold.
+    #[allow(unused_mut)]
+    pub fn score_threshold<VALUE: core::convert::Into<f32>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.score_threshold = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Options for specifying which payload to include or not
+    #[allow(unused_mut)]
+    pub fn with_payload<VALUE: core::convert::Into<WithPayloadSelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_payload = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Options for specifying which vectors to include into response
+    #[allow(unused_mut)]
+    pub fn with_vectors<VALUE: core::convert::Into<WithVectorsSelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_vectors = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector
+    #[allow(unused_mut)]
+    pub fn lookup_from<VALUE: core::convert::Into<LookupLocation>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.lookup_from = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Max number of points. Default is 3.
+    #[allow(unused_mut)]
+    pub fn limit<VALUE: core::convert::Into<u64>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.limit = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Maximum amount of points to return per group. Default to 10.
+    #[allow(unused_mut)]
+    pub fn group_size<VALUE: core::convert::Into<u64>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.group_size = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
+    #[allow(unused_mut)]
+    pub fn group_by(self, value: String) -> Self {
+        let mut new = self;
+        new.group_by = Option::Some(value);
+        new
+    }
+    /// Options for specifying read consistency guarantees
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<ReadConsistency>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Options for specifying how to use the group id to lookup points in another collection
+    #[allow(unused_mut)]
+    pub fn with_lookup<VALUE: core::convert::Into<WithLookup>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.with_lookup = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout<VALUE: core::convert::Into<u64>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `QueryPointGroups`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<QueryPointGroups, QueryPointGroupsBuilderError> {
+        Ok(QueryPointGroups {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            prefetch: match self.prefetch {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            query: match self.query {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            using: match self.using {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            filter: match self.filter {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            params: match self.params {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            score_threshold: match self.score_threshold {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            with_payload: match self.with_payload {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            with_vectors: match self.with_vectors {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            lookup_from: match self.lookup_from {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            limit: match self.limit {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            group_size: match self.group_size {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            group_by: match self.group_by {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("group_by"),
+                    ));
+                }
+            },
+            read_consistency: match self.read_consistency {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            with_lookup: match self.with_lookup {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            prefetch: core::default::Default::default(),
+            query: core::default::Default::default(),
+            using: core::default::Default::default(),
+            filter: core::default::Default::default(),
+            params: core::default::Default::default(),
+            score_threshold: core::default::Default::default(),
+            with_payload: core::default::Default::default(),
+            with_vectors: core::default::Default::default(),
+            lookup_from: core::default::Default::default(),
+            limit: core::default::Default::default(),
+            group_size: core::default::Default::default(),
+            group_by: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            with_lookup: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<QueryPointGroupsBuilder> for QueryPointGroups {
+    fn from(value: QueryPointGroupsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "QueryPointGroupsBuilder", "QueryPointGroups",
+        ))
+    }
+}
+
+impl QueryPointGroupsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> QueryPointGroups {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "QueryPointGroupsBuilder", "QueryPointGroups",
+        ))
+    }
+}
+
+impl QueryPointGroupsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/query_points_builder.rs
+++ b/src/builders/query_points_builder.rs
@@ -1,0 +1,265 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct QueryPointsBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Sub-requests to perform first. If present, the query will be performed on the results of the prefetches.
+    pub(crate) prefetch: Option<Vec<PrefetchQuery>>,
+    /// Query to perform. If missing, returns points ordered by their IDs.
+    pub(crate) query: Option<Option<Query>>,
+    /// Define which vector to use for querying. If missing, the default vector is used.
+    pub(crate) using: Option<Option<String>>,
+    /// Filter conditions - return only those points that satisfy the specified conditions.
+    pub(crate) filter: Option<Option<Filter>>,
+    /// Search params for when there is no prefetch.
+    pub(crate) params: Option<Option<SearchParams>>,
+    /// Return points with scores better than this threshold.
+    pub(crate) score_threshold: Option<Option<f32>>,
+    /// Max number of points. Default is 10.
+    pub(crate) limit: Option<Option<u64>>,
+    /// Offset of the result. Skip this many points. Default is 0.
+    pub(crate) offset: Option<Option<u64>>,
+    /// Options for specifying which vectors to include into the response.
+    with_vectors: Option<with_vectors_selector::SelectorOptions>,
+    /// Options for specifying which payload to include or not.
+    with_payload: Option<with_payload_selector::SelectorOptions>,
+    /// Options for specifying read consistency guarantees.
+    read_consistency: Option<read_consistency::Value>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards.
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+    /// The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector
+    pub(crate) lookup_from: Option<Option<LookupLocation>>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+}
+
+impl QueryPointsBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Sub-requests to perform first. If present, the query will be performed on the results of the prefetches.
+    #[allow(unused_mut)]
+    pub fn prefetch<VALUE: core::convert::Into<Vec<PrefetchQuery>>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.prefetch = Option::Some(value.into());
+        new
+    }
+    /// Query to perform. If missing, returns points ordered by their IDs.
+    #[allow(unused_mut)]
+    pub fn query<VALUE: core::convert::Into<Query>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.query = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Define which vector to use for querying. If missing, the default vector is used.
+    #[allow(unused_mut)]
+    pub fn using<VALUE: core::convert::Into<String>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.using = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Filter conditions - return only those points that satisfy the specified conditions.
+    #[allow(unused_mut)]
+    pub fn filter<VALUE: core::convert::Into<Filter>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.filter = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Search params for when there is no prefetch.
+    #[allow(unused_mut)]
+    pub fn params<VALUE: core::convert::Into<SearchParams>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.params = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Return points with scores better than this threshold.
+    #[allow(unused_mut)]
+    pub fn score_threshold<VALUE: core::convert::Into<f32>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.score_threshold = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Max number of points. Default is 10.
+    #[allow(unused_mut)]
+    pub fn limit(self, value: u64) -> Self {
+        let mut new = self;
+        new.limit = Option::Some(Option::Some(value));
+        new
+    }
+    /// Offset of the result. Skip this many points. Default is 0.
+    #[allow(unused_mut)]
+    pub fn offset(self, value: u64) -> Self {
+        let mut new = self;
+        new.offset = Option::Some(Option::Some(value));
+        new
+    }
+    /// Options for specifying which vectors to include into the response.
+    #[allow(unused_mut)]
+    pub fn with_vectors<VALUE: core::convert::Into<with_vectors_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_vectors = Option::Some(value.into());
+        new
+    }
+    /// Options for specifying which payload to include or not.
+    #[allow(unused_mut)]
+    pub fn with_payload<VALUE: core::convert::Into<with_payload_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_payload = Option::Some(value.into());
+        new
+    }
+    /// Options for specifying read consistency guarantees.
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<read_consistency::Value>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(value.into());
+        new
+    }
+    /// Specify in which shards to look for the points, if not specified - look in all shards.
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// The location to use for IDs lookup, if not specified - use the current collection and the 'using' vector
+    #[allow(unused_mut)]
+    pub fn lookup_from<VALUE: core::convert::Into<LookupLocation>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.lookup_from = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `QueryPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<QueryPoints, QueryPointsBuilderError> {
+        Ok(QueryPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            prefetch: match self.prefetch {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            query: match self.query {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            using: match self.using {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            filter: match self.filter {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            params: match self.params {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            score_threshold: match self.score_threshold {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            limit: match self.limit {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            offset: match self.offset {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            with_vectors: { convert_option(&self.with_vectors) },
+            with_payload: { convert_option(&self.with_payload) },
+            read_consistency: { convert_option(&self.read_consistency) },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            lookup_from: match self.lookup_from {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            prefetch: core::default::Default::default(),
+            query: core::default::Default::default(),
+            using: core::default::Default::default(),
+            filter: core::default::Default::default(),
+            params: core::default::Default::default(),
+            score_threshold: core::default::Default::default(),
+            limit: core::default::Default::default(),
+            offset: core::default::Default::default(),
+            with_vectors: core::default::Default::default(),
+            with_payload: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+            lookup_from: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<QueryPointsBuilder> for QueryPoints {
+    fn from(value: QueryPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "QueryPointsBuilder", "QueryPoints",
+        ))
+    }
+}
+
+impl QueryPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> QueryPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "QueryPointsBuilder", "QueryPoints",
+        ))
+    }
+}
+
+impl QueryPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/recommend_batch_points_builder.rs
+++ b/src/builders/recommend_batch_points_builder.rs
@@ -1,0 +1,110 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct RecommendBatchPointsBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    pub(crate) recommend_points: Option<Vec<RecommendPoints>>,
+    /// Options for specifying read consistency guarantees
+    read_consistency: Option<read_consistency::Value>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+}
+
+impl RecommendBatchPointsBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn recommend_points(self, value: Vec<RecommendPoints>) -> Self {
+        let mut new = self;
+        new.recommend_points = Option::Some(value);
+        new
+    }
+    /// Options for specifying read consistency guarantees
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<read_consistency::Value>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(value.into());
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `RecommendBatchPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<RecommendBatchPoints, RecommendBatchPointsBuilderError> {
+        Ok(RecommendBatchPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            recommend_points: match self.recommend_points {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("recommend_points"),
+                    ));
+                }
+            },
+            read_consistency: { convert_option(&self.read_consistency) },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            recommend_points: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<RecommendBatchPointsBuilder> for RecommendBatchPoints {
+    fn from(value: RecommendBatchPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "RecommendBatchPointsBuilder", "RecommendBatchPoints",
+        ))
+    }
+}
+
+impl RecommendBatchPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> RecommendBatchPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "RecommendBatchPointsBuilder", "RecommendBatchPoints",
+        ))
+    }
+}
+
+impl RecommendBatchPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/recommend_input_builder.rs
+++ b/src/builders/recommend_input_builder.rs
@@ -1,0 +1,83 @@
+use crate::qdrant::*;
+
+pub struct RecommendInputBuilder {
+    /// Look for vectors closest to the vectors from these points
+    pub(crate) positive: Option<Vec<VectorInput>>,
+    /// Try to avoid vectors like the vector from these points
+    pub(crate) negative: Option<Vec<VectorInput>>,
+    /// How to use the provided vectors to find the results
+    pub(crate) strategy: Option<Option<i32>>,
+}
+
+impl RecommendInputBuilder {
+    /// Look for vectors closest to the vectors from these points
+    #[allow(unused_mut)]
+    pub fn positive<VALUE: core::convert::Into<Vec<VectorInput>>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.positive = Option::Some(value.into());
+        new
+    }
+    /// Try to avoid vectors like the vector from these points
+    #[allow(unused_mut)]
+    pub fn negative<VALUE: core::convert::Into<Vec<VectorInput>>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.negative = Option::Some(value.into());
+        new
+    }
+    /// How to use the provided vectors to find the results
+    #[allow(unused_mut)]
+    pub fn strategy<VALUE: core::convert::Into<i32>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.strategy = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `RecommendInput`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<RecommendInput, std::convert::Infallible> {
+        Ok(RecommendInput {
+            positive: match self.positive {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            negative: match self.negative {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            strategy: match self.strategy {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            positive: core::default::Default::default(),
+            negative: core::default::Default::default(),
+            strategy: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<RecommendInputBuilder> for RecommendInput {
+    fn from(value: RecommendInputBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "RecommendInputBuilder", "RecommendInput",
+        ))
+    }
+}
+
+impl RecommendInputBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> RecommendInput {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "RecommendInputBuilder", "RecommendInput",
+        ))
+    }
+}

--- a/src/builders/recommend_point_groups_builder.rs
+++ b/src/builders/recommend_point_groups_builder.rs
@@ -1,0 +1,319 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct RecommendPointGroupsBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Look for vectors closest to the vectors from these points
+    pub(crate) positive: Option<Vec<PointId>>,
+    /// Try to avoid vectors like the vector from these points
+    pub(crate) negative: Option<Vec<PointId>>,
+    /// Filter conditions - return only those points that satisfy the specified conditions
+    pub(crate) filter: Option<Option<Filter>>,
+    /// Max number of groups in result
+    pub(crate) limit: Option<u32>,
+    /// Options for specifying which payload to include or not
+    with_payload: Option<with_payload_selector::SelectorOptions>,
+    /// Search config
+    pub(crate) params: Option<Option<SearchParams>>,
+    /// If provided - cut off results with worse scores
+    pub(crate) score_threshold: Option<Option<f32>>,
+    /// Define which vector to use for recommendation, if not specified - default vector
+    pub(crate) using: Option<Option<String>>,
+    /// Options for specifying which vectors to include into response
+    with_vectors: Option<with_vectors_selector::SelectorOptions>,
+    /// Name of the collection to use for points lookup, if not specified - use current collection
+    pub(crate) lookup_from: Option<Option<LookupLocation>>,
+    /// Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
+    pub(crate) group_by: Option<String>,
+    /// Maximum amount of points to return per group
+    pub(crate) group_size: Option<u32>,
+    /// Options for specifying read consistency guarantees
+    read_consistency: Option<read_consistency::Value>,
+    /// Options for specifying how to use the group id to lookup points in another collection
+    pub(crate) with_lookup: Option<Option<WithLookup>>,
+    /// How to use the example vectors to find the results
+    pub(crate) strategy: Option<Option<i32>>,
+    /// Look for vectors closest to those
+    pub(crate) positive_vectors: Option<Vec<Vector>>,
+    /// Try to avoid vectors like this
+    pub(crate) negative_vectors: Option<Vec<Vector>>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+}
+
+impl RecommendPointGroupsBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Filter conditions - return only those points that satisfy the specified conditions
+    #[allow(unused_mut)]
+    pub fn filter<VALUE: core::convert::Into<Filter>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.filter = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Max number of groups in result
+    #[allow(unused_mut)]
+    pub fn limit(self, value: u32) -> Self {
+        let mut new = self;
+        new.limit = Option::Some(value);
+        new
+    }
+    /// Options for specifying which payload to include or not
+    #[allow(unused_mut)]
+    pub fn with_payload<VALUE: core::convert::Into<with_payload_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_payload = Option::Some(value.into());
+        new
+    }
+    /// Search config
+    #[allow(unused_mut)]
+    pub fn params<VALUE: core::convert::Into<SearchParams>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.params = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If provided - cut off results with worse scores
+    #[allow(unused_mut)]
+    pub fn score_threshold(self, value: f32) -> Self {
+        let mut new = self;
+        new.score_threshold = Option::Some(Option::Some(value));
+        new
+    }
+    /// Define which vector to use for recommendation, if not specified - default vector
+    #[allow(unused_mut)]
+    pub fn using<VALUE: core::convert::Into<String>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.using = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Options for specifying which vectors to include into response
+    #[allow(unused_mut)]
+    pub fn with_vectors<VALUE: core::convert::Into<with_vectors_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_vectors = Option::Some(value.into());
+        new
+    }
+    /// Name of the collection to use for points lookup, if not specified - use current collection
+    #[allow(unused_mut)]
+    pub fn lookup_from<VALUE: core::convert::Into<LookupLocation>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.lookup_from = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
+    #[allow(unused_mut)]
+    pub fn group_by(self, value: String) -> Self {
+        let mut new = self;
+        new.group_by = Option::Some(value);
+        new
+    }
+    /// Maximum amount of points to return per group
+    #[allow(unused_mut)]
+    pub fn group_size(self, value: u32) -> Self {
+        let mut new = self;
+        new.group_size = Option::Some(value);
+        new
+    }
+    /// Options for specifying read consistency guarantees
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<read_consistency::Value>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(value.into());
+        new
+    }
+    /// Options for specifying how to use the group id to lookup points in another collection
+    #[allow(unused_mut)]
+    pub fn with_lookup<VALUE: core::convert::Into<WithLookup>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.with_lookup = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// How to use the example vectors to find the results
+    #[allow(unused_mut)]
+    pub fn strategy<VALUE: core::convert::Into<i32>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.strategy = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `RecommendPointGroups`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<RecommendPointGroups, RecommendPointGroupsBuilderError> {
+        Ok(RecommendPointGroups {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            positive: match self.positive {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            negative: match self.negative {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            filter: match self.filter {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            limit: match self.limit {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("limit"),
+                    ));
+                }
+            },
+            with_payload: { convert_option(&self.with_payload) },
+            params: match self.params {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            score_threshold: match self.score_threshold {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            using: match self.using {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            with_vectors: { convert_option(&self.with_vectors) },
+            lookup_from: match self.lookup_from {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            group_by: match self.group_by {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("group_by"),
+                    ));
+                }
+            },
+            group_size: match self.group_size {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("group_size"),
+                    ));
+                }
+            },
+            read_consistency: { convert_option(&self.read_consistency) },
+            with_lookup: match self.with_lookup {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            strategy: match self.strategy {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            positive_vectors: match self.positive_vectors {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            negative_vectors: match self.negative_vectors {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            positive: core::default::Default::default(),
+            negative: core::default::Default::default(),
+            filter: core::default::Default::default(),
+            limit: core::default::Default::default(),
+            with_payload: core::default::Default::default(),
+            params: core::default::Default::default(),
+            score_threshold: core::default::Default::default(),
+            using: core::default::Default::default(),
+            with_vectors: core::default::Default::default(),
+            lookup_from: core::default::Default::default(),
+            group_by: core::default::Default::default(),
+            group_size: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            with_lookup: core::default::Default::default(),
+            strategy: core::default::Default::default(),
+            positive_vectors: core::default::Default::default(),
+            negative_vectors: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<RecommendPointGroupsBuilder> for RecommendPointGroups {
+    fn from(value: RecommendPointGroupsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "RecommendPointGroupsBuilder", "RecommendPointGroups",
+        ))
+    }
+}
+
+impl RecommendPointGroupsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> RecommendPointGroups {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "RecommendPointGroupsBuilder", "RecommendPointGroups",
+        ))
+    }
+}
+
+impl RecommendPointGroupsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/recommend_points_builder.rs
+++ b/src/builders/recommend_points_builder.rs
@@ -1,0 +1,283 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct RecommendPointsBuilder {
+    /// name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Look for vectors closest to the vectors from these points
+    pub(crate) positive: Option<Vec<PointId>>,
+    /// Try to avoid vectors like the vector from these points
+    pub(crate) negative: Option<Vec<PointId>>,
+    /// Filter conditions - return only those points that satisfy the specified conditions
+    pub(crate) filter: Option<Option<Filter>>,
+    /// Max number of result
+    pub(crate) limit: Option<u64>,
+    /// Options for specifying which payload to include or not
+    with_payload: Option<with_payload_selector::SelectorOptions>,
+    /// Search config
+    pub(crate) params: Option<Option<SearchParams>>,
+    /// If provided - cut off results with worse scores
+    pub(crate) score_threshold: Option<Option<f32>>,
+    /// Offset of the result
+    pub(crate) offset: Option<Option<u64>>,
+    /// Define which vector to use for recommendation, if not specified - default vector
+    pub(crate) using: Option<Option<String>>,
+    /// Options for specifying which vectors to include into response
+    with_vectors: Option<with_vectors_selector::SelectorOptions>,
+    /// Name of the collection to use for points lookup, if not specified - use current collection
+    pub(crate) lookup_from: Option<Option<LookupLocation>>,
+    /// Options for specifying read consistency guarantees
+    read_consistency: Option<read_consistency::Value>,
+    /// How to use the example vectors to find the results
+    pub(crate) strategy: Option<Option<i32>>,
+    /// Look for vectors closest to those
+    pub(crate) positive_vectors: Option<Vec<Vector>>,
+    /// Try to avoid vectors like this
+    pub(crate) negative_vectors: Option<Vec<Vector>>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+}
+
+impl RecommendPointsBuilder {
+    /// name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Filter conditions - return only those points that satisfy the specified conditions
+    #[allow(unused_mut)]
+    pub fn filter<VALUE: core::convert::Into<Filter>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.filter = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Max number of result
+    #[allow(unused_mut)]
+    pub fn limit(self, value: u64) -> Self {
+        let mut new = self;
+        new.limit = Option::Some(value);
+        new
+    }
+    /// Options for specifying which payload to include or not
+    #[allow(unused_mut)]
+    pub fn with_payload<VALUE: core::convert::Into<with_payload_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_payload = Option::Some(value.into());
+        new
+    }
+    /// Search config
+    #[allow(unused_mut)]
+    pub fn params<VALUE: core::convert::Into<SearchParams>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.params = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If provided - cut off results with worse scores
+    #[allow(unused_mut)]
+    pub fn score_threshold(self, value: f32) -> Self {
+        let mut new = self;
+        new.score_threshold = Option::Some(Option::Some(value));
+        new
+    }
+    /// Offset of the result
+    #[allow(unused_mut)]
+    pub fn offset(self, value: u64) -> Self {
+        let mut new = self;
+        new.offset = Option::Some(Option::Some(value));
+        new
+    }
+    /// Define which vector to use for recommendation, if not specified - default vector
+    #[allow(unused_mut)]
+    pub fn using<VALUE: core::convert::Into<String>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.using = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Options for specifying which vectors to include into response
+    #[allow(unused_mut)]
+    pub fn with_vectors<VALUE: core::convert::Into<with_vectors_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_vectors = Option::Some(value.into());
+        new
+    }
+    /// Name of the collection to use for points lookup, if not specified - use current collection
+    #[allow(unused_mut)]
+    pub fn lookup_from<VALUE: core::convert::Into<LookupLocation>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.lookup_from = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Options for specifying read consistency guarantees
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<read_consistency::Value>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(value.into());
+        new
+    }
+    /// How to use the example vectors to find the results
+    #[allow(unused_mut)]
+    pub fn strategy<VALUE: core::convert::Into<i32>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.strategy = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `RecommendPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<RecommendPoints, RecommendPointsBuilderError> {
+        Ok(RecommendPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            positive: match self.positive {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            negative: match self.negative {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            filter: match self.filter {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            limit: match self.limit {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("limit"),
+                    ));
+                }
+            },
+            with_payload: { convert_option(&self.with_payload) },
+            params: match self.params {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            score_threshold: match self.score_threshold {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            offset: match self.offset {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            using: match self.using {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            with_vectors: { convert_option(&self.with_vectors) },
+            lookup_from: match self.lookup_from {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            read_consistency: { convert_option(&self.read_consistency) },
+            strategy: match self.strategy {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            positive_vectors: match self.positive_vectors {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            negative_vectors: match self.negative_vectors {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            positive: core::default::Default::default(),
+            negative: core::default::Default::default(),
+            filter: core::default::Default::default(),
+            limit: core::default::Default::default(),
+            with_payload: core::default::Default::default(),
+            params: core::default::Default::default(),
+            score_threshold: core::default::Default::default(),
+            offset: core::default::Default::default(),
+            using: core::default::Default::default(),
+            with_vectors: core::default::Default::default(),
+            lookup_from: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            strategy: core::default::Default::default(),
+            positive_vectors: core::default::Default::default(),
+            negative_vectors: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<RecommendPointsBuilder> for RecommendPoints {
+    fn from(value: RecommendPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "RecommendPointsBuilder", "RecommendPoints",
+        ))
+    }
+}
+
+impl RecommendPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> RecommendPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "RecommendPointsBuilder", "RecommendPoints",
+        ))
+    }
+}
+
+impl RecommendPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/rename_alias_builder.rs
+++ b/src/builders/rename_alias_builder.rs
@@ -1,0 +1,83 @@
+use crate::qdrant::*;
+
+pub struct RenameAliasBuilder {
+    /// Name of the alias to rename
+    pub(crate) old_alias_name: Option<String>,
+    /// Name of the alias
+    pub(crate) new_alias_name: Option<String>,
+}
+
+impl RenameAliasBuilder {
+    /// Name of the alias to rename
+    #[allow(unused_mut)]
+    pub fn old_alias_name(self, value: String) -> Self {
+        let mut new = self;
+        new.old_alias_name = Option::Some(value);
+        new
+    }
+    /// Name of the alias
+    #[allow(unused_mut)]
+    pub fn new_alias_name(self, value: String) -> Self {
+        let mut new = self;
+        new.new_alias_name = Option::Some(value);
+        new
+    }
+    /**Builds a new `RenameAlias`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<RenameAlias, RenameAliasBuilderError> {
+        Ok(RenameAlias {
+            old_alias_name: match self.old_alias_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("old_alias_name"),
+                    ));
+                }
+            },
+            new_alias_name: match self.new_alias_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("new_alias_name"),
+                    ));
+                }
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            old_alias_name: core::default::Default::default(),
+            new_alias_name: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<RenameAliasBuilder> for RenameAlias {
+    fn from(value: RenameAliasBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "RenameAliasBuilder", "RenameAlias",
+        ))
+    }
+}
+
+impl RenameAliasBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> RenameAlias {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "RenameAliasBuilder", "RenameAlias",
+        ))
+    }
+}
+
+impl RenameAliasBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/replica_builder.rs
+++ b/src/builders/replica_builder.rs
@@ -1,0 +1,79 @@
+use crate::qdrant::*;
+
+pub struct ReplicaBuilder {
+    pub(crate) shard_id: Option<u32>,
+    pub(crate) peer_id: Option<u64>,
+}
+
+impl ReplicaBuilder {
+    #[allow(unused_mut)]
+    pub fn shard_id(self, value: u32) -> Self {
+        let mut new = self;
+        new.shard_id = Option::Some(value);
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn peer_id(self, value: u64) -> Self {
+        let mut new = self;
+        new.peer_id = Option::Some(value);
+        new
+    }
+    /**Builds a new `Replica`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<Replica, ReplicaBuilderError> {
+        Ok(Replica {
+            shard_id: match self.shard_id {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("shard_id"),
+                    ));
+                }
+            },
+            peer_id: match self.peer_id {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("peer_id"),
+                    ));
+                }
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            shard_id: core::default::Default::default(),
+            peer_id: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<ReplicaBuilder> for Replica {
+    fn from(value: ReplicaBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "ReplicaBuilder", "Replica",
+        ))
+    }
+}
+
+impl ReplicaBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> Replica {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "ReplicaBuilder", "Replica",
+        ))
+    }
+}
+
+impl ReplicaBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/replicate_shard_builder.rs
+++ b/src/builders/replicate_shard_builder.rs
@@ -1,0 +1,121 @@
+use crate::qdrant::*;
+
+pub struct ReplicateShardBuilder {
+    /// Local shard id
+    pub(crate) shard_id: Option<u32>,
+    pub(crate) to_shard_id: Option<Option<u32>>,
+    pub(crate) from_peer_id: Option<u64>,
+    pub(crate) to_peer_id: Option<u64>,
+    pub(crate) method: Option<Option<i32>>,
+}
+
+impl ReplicateShardBuilder {
+    /// Local shard id
+    #[allow(unused_mut)]
+    pub fn shard_id(self, value: u32) -> Self {
+        let mut new = self;
+        new.shard_id = Option::Some(value);
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn to_shard_id(self, value: u32) -> Self {
+        let mut new = self;
+        new.to_shard_id = Option::Some(Option::Some(value));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn from_peer_id(self, value: u64) -> Self {
+        let mut new = self;
+        new.from_peer_id = Option::Some(value);
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn to_peer_id(self, value: u64) -> Self {
+        let mut new = self;
+        new.to_peer_id = Option::Some(value);
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn method<VALUE: core::convert::Into<i32>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.method = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `ReplicateShard`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<ReplicateShard, ReplicateShardBuilderError> {
+        Ok(ReplicateShard {
+            shard_id: match self.shard_id {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("shard_id"),
+                    ));
+                }
+            },
+            to_shard_id: match self.to_shard_id {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            from_peer_id: match self.from_peer_id {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("from_peer_id"),
+                    ));
+                }
+            },
+            to_peer_id: match self.to_peer_id {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("to_peer_id"),
+                    ));
+                }
+            },
+            method: match self.method {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            shard_id: core::default::Default::default(),
+            to_shard_id: core::default::Default::default(),
+            from_peer_id: core::default::Default::default(),
+            to_peer_id: core::default::Default::default(),
+            method: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<ReplicateShardBuilder> for ReplicateShard {
+    fn from(value: ReplicateShardBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "ReplicateShardBuilder", "ReplicateShard",
+        ))
+    }
+}
+
+impl ReplicateShardBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> ReplicateShard {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "ReplicateShardBuilder", "ReplicateShard",
+        ))
+    }
+}
+
+impl ReplicateShardBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/scalar_quantization_builder.rs
+++ b/src/builders/scalar_quantization_builder.rs
@@ -1,0 +1,93 @@
+use crate::qdrant::*;
+
+pub struct ScalarQuantizationBuilder {
+    /// Type of quantization
+    pub(crate) r#type: Option<i32>,
+    /// Number of bits to use for quantization
+    pub(crate) quantile: Option<Option<f32>>,
+    /// If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
+    pub(crate) always_ram: Option<Option<bool>>,
+}
+
+impl ScalarQuantizationBuilder {
+    /// Type of quantization
+    #[allow(unused_mut)]
+    pub fn r#type(self, value: i32) -> Self {
+        let mut new = self;
+        new.r#type = Option::Some(value);
+        new
+    }
+    /// Number of bits to use for quantization
+    #[allow(unused_mut)]
+    pub fn quantile(self, value: f32) -> Self {
+        let mut new = self;
+        new.quantile = Option::Some(Option::Some(value));
+        new
+    }
+    /// If true - quantized vectors always will be stored in RAM, ignoring the config of main storage
+    #[allow(unused_mut)]
+    pub fn always_ram(self, value: bool) -> Self {
+        let mut new = self;
+        new.always_ram = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `ScalarQuantization`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<ScalarQuantization, ScalarQuantizationBuilderError> {
+        Ok(ScalarQuantization {
+            r#type: match self.r#type {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("r#type"),
+                    ));
+                }
+            },
+            quantile: match self.quantile {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            always_ram: match self.always_ram {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            r#type: core::default::Default::default(),
+            quantile: core::default::Default::default(),
+            always_ram: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<ScalarQuantizationBuilder> for ScalarQuantization {
+    fn from(value: ScalarQuantizationBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "ScalarQuantizationBuilder", "ScalarQuantization",
+        ))
+    }
+}
+
+impl ScalarQuantizationBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> ScalarQuantization {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "ScalarQuantizationBuilder", "ScalarQuantization",
+        ))
+    }
+}
+
+impl ScalarQuantizationBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/scroll_points_builder.rs
+++ b/src/builders/scroll_points_builder.rs
@@ -1,0 +1,193 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct ScrollPointsBuilder {
+    pub(crate) collection_name: Option<String>,
+    /// Filter conditions - return only those points that satisfy the specified conditions
+    pub(crate) filter: Option<Option<Filter>>,
+    /// Start with this ID
+    pub(crate) offset: Option<Option<PointId>>,
+    /// Max number of result
+    pub(crate) limit: Option<Option<u32>>,
+    /// Options for specifying which payload to include or not
+    with_payload: Option<with_payload_selector::SelectorOptions>,
+    /// Options for specifying which vectors to include into response
+    with_vectors: Option<with_vectors_selector::SelectorOptions>,
+    /// Options for specifying read consistency guarantees
+    read_consistency: Option<read_consistency::Value>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+    /// Order the records by a payload field
+    pub(crate) order_by: Option<Option<OrderBy>>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+}
+
+impl ScrollPointsBuilder {
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Filter conditions - return only those points that satisfy the specified conditions
+    #[allow(unused_mut)]
+    pub fn filter<VALUE: core::convert::Into<Filter>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.filter = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Start with this ID
+    #[allow(unused_mut)]
+    pub fn offset<VALUE: core::convert::Into<PointId>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.offset = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Max number of result
+    #[allow(unused_mut)]
+    pub fn limit(self, value: u32) -> Self {
+        let mut new = self;
+        new.limit = Option::Some(Option::Some(value));
+        new
+    }
+    /// Options for specifying which payload to include or not
+    #[allow(unused_mut)]
+    pub fn with_payload<VALUE: core::convert::Into<with_payload_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_payload = Option::Some(value.into());
+        new
+    }
+    /// Options for specifying which vectors to include into response
+    #[allow(unused_mut)]
+    pub fn with_vectors<VALUE: core::convert::Into<with_vectors_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_vectors = Option::Some(value.into());
+        new
+    }
+    /// Options for specifying read consistency guarantees
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<read_consistency::Value>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(value.into());
+        new
+    }
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Order the records by a payload field
+    #[allow(unused_mut)]
+    pub fn order_by<VALUE: core::convert::Into<OrderBy>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.order_by = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `ScrollPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<ScrollPoints, ScrollPointsBuilderError> {
+        Ok(ScrollPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            filter: match self.filter {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            offset: match self.offset {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            limit: match self.limit {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            with_payload: { convert_option(&self.with_payload) },
+            with_vectors: { convert_option(&self.with_vectors) },
+            read_consistency: { convert_option(&self.read_consistency) },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            order_by: match self.order_by {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            filter: core::default::Default::default(),
+            offset: core::default::Default::default(),
+            limit: core::default::Default::default(),
+            with_payload: core::default::Default::default(),
+            with_vectors: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+            order_by: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<ScrollPointsBuilder> for ScrollPoints {
+    fn from(value: ScrollPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "ScrollPointsBuilder", "ScrollPoints",
+        ))
+    }
+}
+
+impl ScrollPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> ScrollPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "ScrollPointsBuilder", "ScrollPoints",
+        ))
+    }
+}
+
+impl ScrollPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/search_batch_points_builder.rs
+++ b/src/builders/search_batch_points_builder.rs
@@ -1,0 +1,110 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct SearchBatchPointsBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    pub(crate) search_points: Option<Vec<SearchPoints>>,
+    /// Options for specifying read consistency guarantees
+    read_consistency: Option<read_consistency::Value>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+}
+
+impl SearchBatchPointsBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn search_points(self, value: Vec<SearchPoints>) -> Self {
+        let mut new = self;
+        new.search_points = Option::Some(value);
+        new
+    }
+    /// Options for specifying read consistency guarantees
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<read_consistency::Value>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(value.into());
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `SearchBatchPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<SearchBatchPoints, SearchBatchPointsBuilderError> {
+        Ok(SearchBatchPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            search_points: match self.search_points {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("search_points"),
+                    ));
+                }
+            },
+            read_consistency: { convert_option(&self.read_consistency) },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            search_points: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<SearchBatchPointsBuilder> for SearchBatchPoints {
+    fn from(value: SearchBatchPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "SearchBatchPointsBuilder", "SearchBatchPoints",
+        ))
+    }
+}
+
+impl SearchBatchPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> SearchBatchPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "SearchBatchPointsBuilder", "SearchBatchPoints",
+        ))
+    }
+}
+
+impl SearchBatchPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/search_matrix_points_builder.rs
+++ b/src/builders/search_matrix_points_builder.rs
@@ -1,0 +1,169 @@
+use crate::qdrant::*;
+
+pub struct SearchMatrixPointsBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Filter conditions - return only those points that satisfy the specified conditions.
+    pub(crate) filter: Option<Option<Filter>>,
+    /// How many points to select and search within. Default is 10.
+    pub(crate) sample: Option<Option<u64>>,
+    /// How many neighbours per sample to find. Default is 3.
+    pub(crate) limit: Option<Option<u64>>,
+    /// Define which vector to use for querying. If missing, the default vector is is used.
+    pub(crate) using: Option<Option<String>>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+    /// Options for specifying read consistency guarantees
+    pub(crate) read_consistency: Option<Option<ReadConsistency>>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+}
+
+impl SearchMatrixPointsBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Filter conditions - return only those points that satisfy the specified conditions.
+    #[allow(unused_mut)]
+    pub fn filter<VALUE: core::convert::Into<Filter>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.filter = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// How many points to select and search within. Default is 10.
+    #[allow(unused_mut)]
+    pub fn sample(self, value: u64) -> Self {
+        let mut new = self;
+        new.sample = Option::Some(Option::Some(value));
+        new
+    }
+    /// How many neighbours per sample to find. Default is 3.
+    #[allow(unused_mut)]
+    pub fn limit(self, value: u64) -> Self {
+        let mut new = self;
+        new.limit = Option::Some(Option::Some(value));
+        new
+    }
+    /// Define which vector to use for querying. If missing, the default vector is is used.
+    #[allow(unused_mut)]
+    pub fn using<VALUE: core::convert::Into<String>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.using = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /// Options for specifying read consistency guarantees
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<ReadConsistency>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `SearchMatrixPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<SearchMatrixPoints, SearchMatrixPointsBuilderError> {
+        Ok(SearchMatrixPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            filter: match self.filter {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            sample: match self.sample {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            limit: match self.limit {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            using: match self.using {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            read_consistency: match self.read_consistency {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            filter: core::default::Default::default(),
+            sample: core::default::Default::default(),
+            limit: core::default::Default::default(),
+            using: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<SearchMatrixPointsBuilder> for SearchMatrixPoints {
+    fn from(value: SearchMatrixPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "SearchMatrixPointsBuilder", "SearchMatrixPoints",
+        ))
+    }
+}
+
+impl SearchMatrixPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> SearchMatrixPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "SearchMatrixPointsBuilder", "SearchMatrixPoints",
+        ))
+    }
+}
+
+impl SearchMatrixPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/search_params_builder.rs
+++ b/src/builders/search_params_builder.rs
@@ -1,0 +1,114 @@
+use crate::qdrant::*;
+
+pub struct SearchParamsBuilder {
+    ///
+    /// Params relevant to HNSW index. Size of the beam in a beam-search.
+    /// Larger the value - more accurate the result, more time required for search.
+    pub(crate) hnsw_ef: Option<Option<u64>>,
+    ///
+    /// Search without approximation. If set to true, search may run long but with exact results.
+    pub(crate) exact: Option<Option<bool>>,
+    ///
+    /// If set to true, search will ignore quantized vector data
+    pub(crate) quantization: Option<Option<QuantizationSearchParams>>,
+    ///
+    /// If enabled, the engine will only perform search among indexed or small segments.
+    /// Using this option prevents slow searches in case of delayed index, but does not
+    /// guarantee that all uploaded vectors will be included in search results
+    pub(crate) indexed_only: Option<Option<bool>>,
+}
+
+impl SearchParamsBuilder {
+    ///
+    /// Params relevant to HNSW index. Size of the beam in a beam-search.
+    /// Larger the value - more accurate the result, more time required for search.
+    #[allow(unused_mut)]
+    pub fn hnsw_ef(self, value: u64) -> Self {
+        let mut new = self;
+        new.hnsw_ef = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// Search without approximation. If set to true, search may run long but with exact results.
+    #[allow(unused_mut)]
+    pub fn exact(self, value: bool) -> Self {
+        let mut new = self;
+        new.exact = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// If set to true, search will ignore quantized vector data
+    #[allow(unused_mut)]
+    pub fn quantization<VALUE: core::convert::Into<QuantizationSearchParams>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.quantization = Option::Some(Option::Some(value.into()));
+        new
+    }
+    ///
+    /// If enabled, the engine will only perform search among indexed or small segments.
+    /// Using this option prevents slow searches in case of delayed index, but does not
+    /// guarantee that all uploaded vectors will be included in search results
+    #[allow(unused_mut)]
+    pub fn indexed_only(self, value: bool) -> Self {
+        let mut new = self;
+        new.indexed_only = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `SearchParams`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<SearchParams, std::convert::Infallible> {
+        Ok(SearchParams {
+            hnsw_ef: match self.hnsw_ef {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            exact: match self.exact {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            quantization: match self.quantization {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            indexed_only: match self.indexed_only {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            hnsw_ef: core::default::Default::default(),
+            exact: core::default::Default::default(),
+            quantization: core::default::Default::default(),
+            indexed_only: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<SearchParamsBuilder> for SearchParams {
+    fn from(value: SearchParamsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "SearchParamsBuilder", "SearchParams",
+        ))
+    }
+}
+
+impl SearchParamsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> SearchParams {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "SearchParamsBuilder", "SearchParams",
+        ))
+    }
+}

--- a/src/builders/search_point_groups_builder.rs
+++ b/src/builders/search_point_groups_builder.rs
@@ -1,0 +1,293 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct SearchPointGroupsBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Vector to compare against
+    pub(crate) vector: Option<Vec<f32>>,
+    /// Filter conditions - return only those points that satisfy the specified conditions
+    pub(crate) filter: Option<Option<Filter>>,
+    /// Max number of result
+    pub(crate) limit: Option<u32>,
+    /// Options for specifying which payload to include or not
+    with_payload: Option<with_payload_selector::SelectorOptions>,
+    /// Search config
+    pub(crate) params: Option<Option<SearchParams>>,
+    /// If provided - cut off results with worse scores
+    pub(crate) score_threshold: Option<Option<f32>>,
+    /// Which vector to use for search, if not specified - use default vector
+    pub(crate) vector_name: Option<Option<String>>,
+    /// Options for specifying which vectors to include into response
+    with_vectors: Option<with_vectors_selector::SelectorOptions>,
+    /// Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
+    pub(crate) group_by: Option<String>,
+    /// Maximum amount of points to return per group
+    pub(crate) group_size: Option<u32>,
+    /// Options for specifying read consistency guarantees
+    read_consistency: Option<read_consistency::Value>,
+    /// Options for specifying how to use the group id to lookup points in another collection
+    pub(crate) with_lookup: Option<Option<WithLookup>>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+    pub(crate) sparse_indices: Option<Option<SparseIndices>>,
+}
+
+impl SearchPointGroupsBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Vector to compare against
+    #[allow(unused_mut)]
+    pub fn vector(self, value: Vec<f32>) -> Self {
+        let mut new = self;
+        new.vector = Option::Some(value);
+        new
+    }
+    /// Filter conditions - return only those points that satisfy the specified conditions
+    #[allow(unused_mut)]
+    pub fn filter<VALUE: core::convert::Into<Filter>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.filter = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Max number of result
+    #[allow(unused_mut)]
+    pub fn limit(self, value: u32) -> Self {
+        let mut new = self;
+        new.limit = Option::Some(value);
+        new
+    }
+    /// Options for specifying which payload to include or not
+    #[allow(unused_mut)]
+    pub fn with_payload<VALUE: core::convert::Into<with_payload_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_payload = Option::Some(value.into());
+        new
+    }
+    /// Search config
+    #[allow(unused_mut)]
+    pub fn params<VALUE: core::convert::Into<SearchParams>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.params = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If provided - cut off results with worse scores
+    #[allow(unused_mut)]
+    pub fn score_threshold<VALUE: core::convert::Into<f32>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.score_threshold = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Which vector to use for search, if not specified - use default vector
+    #[allow(unused_mut)]
+    pub fn vector_name<VALUE: core::convert::Into<String>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.vector_name = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Options for specifying which vectors to include into response
+    #[allow(unused_mut)]
+    pub fn with_vectors<VALUE: core::convert::Into<with_vectors_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_vectors = Option::Some(value.into());
+        new
+    }
+    /// Payload field to group by, must be a string or number field. If there are multiple values for the field, all of them will be used. One point can be in multiple groups.
+    #[allow(unused_mut)]
+    pub fn group_by(self, value: String) -> Self {
+        let mut new = self;
+        new.group_by = Option::Some(value);
+        new
+    }
+    /// Maximum amount of points to return per group
+    #[allow(unused_mut)]
+    pub fn group_size(self, value: u32) -> Self {
+        let mut new = self;
+        new.group_size = Option::Some(value);
+        new
+    }
+    /// Options for specifying read consistency guarantees
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<read_consistency::Value>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(value.into());
+        new
+    }
+    /// Options for specifying how to use the group id to lookup points in another collection
+    #[allow(unused_mut)]
+    pub fn with_lookup<VALUE: core::convert::Into<WithLookup>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.with_lookup = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout<VALUE: core::convert::Into<u64>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn sparse_indices<VALUE: core::convert::Into<SparseIndices>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.sparse_indices = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `SearchPointGroups`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<SearchPointGroups, SearchPointGroupsBuilderError> {
+        Ok(SearchPointGroups {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            vector: match self.vector {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("vector"),
+                    ));
+                }
+            },
+            filter: match self.filter {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            limit: match self.limit {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("limit"),
+                    ));
+                }
+            },
+            with_payload: { convert_option(&self.with_payload) },
+            params: match self.params {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            score_threshold: match self.score_threshold {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            vector_name: match self.vector_name {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            with_vectors: { convert_option(&self.with_vectors) },
+            group_by: match self.group_by {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("group_by"),
+                    ));
+                }
+            },
+            group_size: match self.group_size {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("group_size"),
+                    ));
+                }
+            },
+            read_consistency: { convert_option(&self.read_consistency) },
+            with_lookup: match self.with_lookup {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            sparse_indices: match self.sparse_indices {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            vector: core::default::Default::default(),
+            filter: core::default::Default::default(),
+            limit: core::default::Default::default(),
+            with_payload: core::default::Default::default(),
+            params: core::default::Default::default(),
+            score_threshold: core::default::Default::default(),
+            vector_name: core::default::Default::default(),
+            with_vectors: core::default::Default::default(),
+            group_by: core::default::Default::default(),
+            group_size: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            with_lookup: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+            sparse_indices: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<SearchPointGroupsBuilder> for SearchPointGroups {
+    fn from(value: SearchPointGroupsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "SearchPointGroupsBuilder", "SearchPointGroups",
+        ))
+    }
+}
+
+impl SearchPointGroupsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> SearchPointGroups {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "SearchPointGroupsBuilder", "SearchPointGroups",
+        ))
+    }
+}
+
+impl SearchPointGroupsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/search_points_builder.rs
+++ b/src/builders/search_points_builder.rs
@@ -1,0 +1,257 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct SearchPointsBuilder {
+    /// name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// vector
+    pub(crate) vector: Option<Vec<f32>>,
+    /// Filter conditions - return only those points that satisfy the specified conditions
+    pub(crate) filter: Option<Option<Filter>>,
+    /// Max number of result
+    pub(crate) limit: Option<u64>,
+    /// Options for specifying which payload to include or not
+    with_payload: Option<with_payload_selector::SelectorOptions>,
+    /// Search config
+    pub(crate) params: Option<Option<SearchParams>>,
+    /// If provided - cut off results with worse scores
+    pub(crate) score_threshold: Option<Option<f32>>,
+    /// Offset of the result
+    pub(crate) offset: Option<Option<u64>>,
+    /// Which vector to use for search, if not specified - use default vector
+    pub(crate) vector_name: Option<Option<String>>,
+    /// Options for specifying which vectors to include into response
+    with_vectors: Option<with_vectors_selector::SelectorOptions>,
+    /// Options for specifying read consistency guarantees
+    read_consistency: Option<read_consistency::Value>,
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    pub(crate) timeout: Option<Option<u64>>,
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+    pub(crate) sparse_indices: Option<Option<SparseIndices>>,
+}
+
+impl SearchPointsBuilder {
+    /// name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// vector
+    #[allow(unused_mut)]
+    pub fn vector(self, value: Vec<f32>) -> Self {
+        let mut new = self;
+        new.vector = Option::Some(value);
+        new
+    }
+    /// Filter conditions - return only those points that satisfy the specified conditions
+    #[allow(unused_mut)]
+    pub fn filter<VALUE: core::convert::Into<Filter>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.filter = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Max number of result
+    #[allow(unused_mut)]
+    pub fn limit(self, value: u64) -> Self {
+        let mut new = self;
+        new.limit = Option::Some(value);
+        new
+    }
+    /// Options for specifying which payload to include or not
+    #[allow(unused_mut)]
+    pub fn with_payload<VALUE: core::convert::Into<with_payload_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_payload = Option::Some(value.into());
+        new
+    }
+    /// Search config
+    #[allow(unused_mut)]
+    pub fn params<VALUE: core::convert::Into<SearchParams>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.params = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If provided - cut off results with worse scores
+    #[allow(unused_mut)]
+    pub fn score_threshold(self, value: f32) -> Self {
+        let mut new = self;
+        new.score_threshold = Option::Some(Option::Some(value));
+        new
+    }
+    /// Offset of the result
+    #[allow(unused_mut)]
+    pub fn offset(self, value: u64) -> Self {
+        let mut new = self;
+        new.offset = Option::Some(Option::Some(value));
+        new
+    }
+    /// Which vector to use for search, if not specified - use default vector
+    #[allow(unused_mut)]
+    pub fn vector_name<VALUE: core::convert::Into<String>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.vector_name = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Options for specifying which vectors to include into response
+    #[allow(unused_mut)]
+    pub fn with_vectors<VALUE: core::convert::Into<with_vectors_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_vectors = Option::Some(value.into());
+        new
+    }
+    /// Options for specifying read consistency guarantees
+    #[allow(unused_mut)]
+    pub fn read_consistency<VALUE: core::convert::Into<read_consistency::Value>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.read_consistency = Option::Some(value.into());
+        new
+    }
+    /// If set, overrides global timeout setting for this request. Unit is seconds.
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /// Specify in which shards to look for the points, if not specified - look in all shards
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn sparse_indices<VALUE: core::convert::Into<SparseIndices>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.sparse_indices = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `SearchPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<SearchPoints, SearchPointsBuilderError> {
+        Ok(SearchPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            vector: match self.vector {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("vector"),
+                    ));
+                }
+            },
+            filter: match self.filter {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            limit: match self.limit {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("limit"),
+                    ));
+                }
+            },
+            with_payload: { convert_option(&self.with_payload) },
+            params: match self.params {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            score_threshold: match self.score_threshold {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            offset: match self.offset {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            vector_name: match self.vector_name {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            with_vectors: { convert_option(&self.with_vectors) },
+            read_consistency: { convert_option(&self.read_consistency) },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            sparse_indices: match self.sparse_indices {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            vector: core::default::Default::default(),
+            filter: core::default::Default::default(),
+            limit: core::default::Default::default(),
+            with_payload: core::default::Default::default(),
+            params: core::default::Default::default(),
+            score_threshold: core::default::Default::default(),
+            offset: core::default::Default::default(),
+            vector_name: core::default::Default::default(),
+            with_vectors: core::default::Default::default(),
+            read_consistency: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+            sparse_indices: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<SearchPointsBuilder> for SearchPoints {
+    fn from(value: SearchPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "SearchPointsBuilder", "SearchPoints",
+        ))
+    }
+}
+
+impl SearchPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> SearchPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "SearchPointsBuilder", "SearchPoints",
+        ))
+    }
+}
+
+impl SearchPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/set_payload_points_builder.rs
+++ b/src/builders/set_payload_points_builder.rs
@@ -1,0 +1,157 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct SetPayloadPointsBuilder {
+    /// name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Wait until the changes have been applied?
+    pub(crate) wait: Option<Option<bool>>,
+    /// New payload values
+    pub(crate) payload: Option<::std::collections::HashMap<String, Value>>,
+    /// Affected points
+    points_selector: Option<points_selector::PointsSelectorOneOf>,
+    /// Write ordering guarantees
+    pub(crate) ordering: Option<Option<WriteOrdering>>,
+    /// Option for custom sharding to specify used shard keys
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+    /// Option for indicate property of payload
+    pub(crate) key: Option<Option<String>>,
+}
+
+impl SetPayloadPointsBuilder {
+    /// name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Wait until the changes have been applied?
+    #[allow(unused_mut)]
+    pub fn wait(self, value: bool) -> Self {
+        let mut new = self;
+        new.wait = Option::Some(Option::Some(value));
+        new
+    }
+    /// New payload values
+    #[allow(unused_mut)]
+    pub fn payload(self, value: ::std::collections::HashMap<String, Value>) -> Self {
+        let mut new = self;
+        new.payload = Option::Some(value);
+        new
+    }
+    /// Affected points
+    #[allow(unused_mut)]
+    pub fn points_selector<VALUE: core::convert::Into<points_selector::PointsSelectorOneOf>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.points_selector = Option::Some(value.into());
+        new
+    }
+    /// Write ordering guarantees
+    #[allow(unused_mut)]
+    pub fn ordering<VALUE: core::convert::Into<WriteOrdering>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.ordering = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Option for custom sharding to specify used shard keys
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Option for indicate property of payload
+    #[allow(unused_mut)]
+    pub fn key<VALUE: core::convert::Into<String>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.key = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `SetPayloadPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<SetPayloadPoints, SetPayloadPointsBuilderError> {
+        Ok(SetPayloadPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            wait: match self.wait {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            payload: match self.payload {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("payload"),
+                    ));
+                }
+            },
+            points_selector: { convert_option(&self.points_selector) },
+            ordering: match self.ordering {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            key: match self.key {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            wait: core::default::Default::default(),
+            payload: core::default::Default::default(),
+            points_selector: core::default::Default::default(),
+            ordering: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+            key: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<SetPayloadPointsBuilder> for SetPayloadPoints {
+    fn from(value: SetPayloadPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "SetPayloadPointsBuilder", "SetPayloadPoints",
+        ))
+    }
+}
+
+impl SetPayloadPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> SetPayloadPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "SetPayloadPointsBuilder", "SetPayloadPoints",
+        ))
+    }
+}
+
+impl SetPayloadPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/sparse_index_config_builder.rs
+++ b/src/builders/sparse_index_config_builder.rs
@@ -1,0 +1,91 @@
+use crate::qdrant::*;
+
+pub struct SparseIndexConfigBuilder {
+    ///
+    /// Prefer a full scan search upto (excluding) this number of vectors.
+    /// Note: this is number of vectors, not KiloBytes.
+    pub(crate) full_scan_threshold: Option<Option<u64>>,
+    ///
+    /// Store inverted index on disk. If set to false, the index will be stored in RAM.
+    pub(crate) on_disk: Option<Option<bool>>,
+    ///
+    /// Datatype used to store weights in the index.
+    pub(crate) datatype: Option<Option<i32>>,
+}
+
+impl SparseIndexConfigBuilder {
+    ///
+    /// Prefer a full scan search upto (excluding) this number of vectors.
+    /// Note: this is number of vectors, not KiloBytes.
+    #[allow(unused_mut)]
+    pub fn full_scan_threshold<VALUE: core::convert::Into<u64>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.full_scan_threshold = Option::Some(Option::Some(value.into()));
+        new
+    }
+    ///
+    /// Store inverted index on disk. If set to false, the index will be stored in RAM.
+    #[allow(unused_mut)]
+    pub fn on_disk(self, value: bool) -> Self {
+        let mut new = self;
+        new.on_disk = Option::Some(Option::Some(value));
+        new
+    }
+    ///
+    /// Datatype used to store weights in the index.
+    #[allow(unused_mut)]
+    pub fn datatype<VALUE: core::convert::Into<i32>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.datatype = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `SparseIndexConfig`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<SparseIndexConfig, std::convert::Infallible> {
+        Ok(SparseIndexConfig {
+            full_scan_threshold: match self.full_scan_threshold {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            on_disk: match self.on_disk {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            datatype: match self.datatype {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            full_scan_threshold: core::default::Default::default(),
+            on_disk: core::default::Default::default(),
+            datatype: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<SparseIndexConfigBuilder> for SparseIndexConfig {
+    fn from(value: SparseIndexConfigBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "SparseIndexConfigBuilder", "SparseIndexConfig",
+        ))
+    }
+}
+
+impl SparseIndexConfigBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> SparseIndexConfig {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "SparseIndexConfigBuilder", "SparseIndexConfig",
+        ))
+    }
+}

--- a/src/builders/sparse_vector_params_builder.rs
+++ b/src/builders/sparse_vector_params_builder.rs
@@ -1,0 +1,10 @@
+use crate::qdrant::*;
+
+pub struct SparseVectorParamsBuilder {
+    /// Configuration of sparse index
+    pub(crate) index:
+        Option<Option<SparseIndexConfig>>,
+    /// If set - apply modifier to the vector values
+    pub(crate) modifier:
+        Option<Option<i32>>,
+}

--- a/src/builders/strict_mode_config_builder.rs
+++ b/src/builders/strict_mode_config_builder.rs
@@ -1,0 +1,137 @@
+use crate::qdrant::*;
+
+pub struct StrictModeConfigBuilder {
+    pub(crate) enabled: Option<Option<bool>>,
+    pub(crate) max_query_limit: Option<Option<u32>>,
+    pub(crate) max_timeout: Option<Option<u32>>,
+    pub(crate) unindexed_filtering_retrieve: Option<Option<bool>>,
+    pub(crate) unindexed_filtering_update: Option<Option<bool>>,
+    pub(crate) search_max_hnsw_ef: Option<Option<u32>>,
+    pub(crate) search_allow_exact: Option<Option<bool>>,
+    pub(crate) search_max_oversampling: Option<Option<f32>>,
+}
+
+impl StrictModeConfigBuilder {
+    #[allow(unused_mut)]
+    pub fn enabled(self, value: bool) -> Self {
+        let mut new = self;
+        new.enabled = Option::Some(Option::Some(value));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn max_query_limit(self, value: u32) -> Self {
+        let mut new = self;
+        new.max_query_limit = Option::Some(Option::Some(value));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn max_timeout(self, value: u32) -> Self {
+        let mut new = self;
+        new.max_timeout = Option::Some(Option::Some(value));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn unindexed_filtering_retrieve(self, value: bool) -> Self {
+        let mut new = self;
+        new.unindexed_filtering_retrieve = Option::Some(Option::Some(value));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn unindexed_filtering_update(self, value: bool) -> Self {
+        let mut new = self;
+        new.unindexed_filtering_update = Option::Some(Option::Some(value));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn search_max_hnsw_ef(self, value: u32) -> Self {
+        let mut new = self;
+        new.search_max_hnsw_ef = Option::Some(Option::Some(value));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn search_allow_exact(self, value: bool) -> Self {
+        let mut new = self;
+        new.search_allow_exact = Option::Some(Option::Some(value));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn search_max_oversampling(self, value: f32) -> Self {
+        let mut new = self;
+        new.search_max_oversampling = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `StrictModeConfig`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<StrictModeConfig, std::convert::Infallible> {
+        Ok(StrictModeConfig {
+            enabled: match self.enabled {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            max_query_limit: match self.max_query_limit {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            max_timeout: match self.max_timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            unindexed_filtering_retrieve: match self.unindexed_filtering_retrieve {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            unindexed_filtering_update: match self.unindexed_filtering_update {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            search_max_hnsw_ef: match self.search_max_hnsw_ef {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            search_allow_exact: match self.search_allow_exact {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            search_max_oversampling: match self.search_max_oversampling {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            enabled: core::default::Default::default(),
+            max_query_limit: core::default::Default::default(),
+            max_timeout: core::default::Default::default(),
+            unindexed_filtering_retrieve: core::default::Default::default(),
+            unindexed_filtering_update: core::default::Default::default(),
+            search_max_hnsw_ef: core::default::Default::default(),
+            search_allow_exact: core::default::Default::default(),
+            search_max_oversampling: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<StrictModeConfigBuilder> for StrictModeConfig {
+    fn from(value: StrictModeConfigBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "StrictModeConfigBuilder", "StrictModeConfig",
+        ))
+    }
+}
+
+impl StrictModeConfigBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> StrictModeConfig {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "StrictModeConfigBuilder", "StrictModeConfig",
+        ))
+    }
+}

--- a/src/builders/text_index_params_builder.rs
+++ b/src/builders/text_index_params_builder.rs
@@ -1,0 +1,121 @@
+use crate::qdrant::*;
+
+pub struct TextIndexParamsBuilder {
+    /// Tokenizer type
+    pub(crate) tokenizer: Option<i32>,
+    /// If true - all tokens will be lowercase
+    pub(crate) lowercase: Option<Option<bool>>,
+    /// Minimal token length
+    pub(crate) min_token_len: Option<Option<u64>>,
+    /// Maximal token length
+    pub(crate) max_token_len: Option<Option<u64>>,
+    /// If true - store index on disk.
+    pub(crate) on_disk: Option<Option<bool>>,
+}
+
+impl TextIndexParamsBuilder {
+    /// Tokenizer type
+    #[allow(unused_mut)]
+    pub fn tokenizer(self, value: i32) -> Self {
+        let mut new = self;
+        new.tokenizer = Option::Some(value);
+        new
+    }
+    /// If true - all tokens will be lowercase
+    #[allow(unused_mut)]
+    pub fn lowercase(self, value: bool) -> Self {
+        let mut new = self;
+        new.lowercase = Option::Some(Option::Some(value));
+        new
+    }
+    /// Minimal token length
+    #[allow(unused_mut)]
+    pub fn min_token_len(self, value: u64) -> Self {
+        let mut new = self;
+        new.min_token_len = Option::Some(Option::Some(value));
+        new
+    }
+    /// Maximal token length
+    #[allow(unused_mut)]
+    pub fn max_token_len(self, value: u64) -> Self {
+        let mut new = self;
+        new.max_token_len = Option::Some(Option::Some(value));
+        new
+    }
+    /// If true - store index on disk.
+    #[allow(unused_mut)]
+    pub fn on_disk(self, value: bool) -> Self {
+        let mut new = self;
+        new.on_disk = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `TextIndexParams`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<TextIndexParams, TextIndexParamsBuilderError> {
+        Ok(TextIndexParams {
+            tokenizer: match self.tokenizer {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("tokenizer"),
+                    ));
+                }
+            },
+            lowercase: match self.lowercase {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            min_token_len: match self.min_token_len {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            max_token_len: match self.max_token_len {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            on_disk: match self.on_disk {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            tokenizer: core::default::Default::default(),
+            lowercase: core::default::Default::default(),
+            min_token_len: core::default::Default::default(),
+            max_token_len: core::default::Default::default(),
+            on_disk: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<TextIndexParamsBuilder> for TextIndexParams {
+    fn from(value: TextIndexParamsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "TextIndexParamsBuilder", "TextIndexParams",
+        ))
+    }
+}
+
+impl TextIndexParamsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> TextIndexParams {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "TextIndexParamsBuilder", "TextIndexParams",
+        ))
+    }
+}
+
+impl TextIndexParamsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/update_batch_points_builder.rs
+++ b/src/builders/update_batch_points_builder.rs
@@ -1,0 +1,109 @@
+use crate::qdrant::*;
+
+pub struct UpdateBatchPointsBuilder {
+    /// name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Wait until the changes have been applied?
+    pub(crate) wait: Option<Option<bool>>,
+    pub(crate) operations: Option<Vec<PointsUpdateOperation>>,
+    /// Write ordering guarantees
+    pub(crate) ordering: Option<Option<WriteOrdering>>,
+}
+
+impl UpdateBatchPointsBuilder {
+    /// name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Wait until the changes have been applied?
+    #[allow(unused_mut)]
+    pub fn wait(self, value: bool) -> Self {
+        let mut new = self;
+        new.wait = Option::Some(Option::Some(value));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn operations(self, value: Vec<PointsUpdateOperation>) -> Self {
+        let mut new = self;
+        new.operations = Option::Some(value);
+        new
+    }
+    /// Write ordering guarantees
+    #[allow(unused_mut)]
+    pub fn ordering<VALUE: core::convert::Into<WriteOrdering>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.ordering = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `UpdateBatchPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<UpdateBatchPoints, UpdateBatchPointsBuilderError> {
+        Ok(UpdateBatchPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            wait: match self.wait {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            operations: match self.operations {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("operations"),
+                    ));
+                }
+            },
+            ordering: match self.ordering {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            wait: core::default::Default::default(),
+            operations: core::default::Default::default(),
+            ordering: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<UpdateBatchPointsBuilder> for UpdateBatchPoints {
+    fn from(value: UpdateBatchPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "UpdateBatchPointsBuilder", "UpdateBatchPoints",
+        ))
+    }
+}
+
+impl UpdateBatchPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> UpdateBatchPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "UpdateBatchPointsBuilder", "UpdateBatchPoints",
+        ))
+    }
+}
+
+impl UpdateBatchPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/update_collection_builder.rs
+++ b/src/builders/update_collection_builder.rs
@@ -1,0 +1,175 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct UpdateCollectionBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// New configuration parameters for the collection. This operation is blocking, it will only proceed once all current optimizations are complete
+    pub(crate) optimizers_config: Option<Option<OptimizersConfigDiff>>,
+    /// Wait timeout for operation commit in seconds if blocking, if not specified - default value will be supplied
+    pub(crate) timeout: Option<Option<u64>>,
+    /// New configuration parameters for the collection
+    pub(crate) params: Option<Option<CollectionParamsDiff>>,
+    /// New HNSW parameters for the collection index
+    pub(crate) hnsw_config: Option<Option<HnswConfigDiff>>,
+    /// New vector parameters
+    pub(crate) vectors_config: Option<Option<VectorsConfigDiff>>,
+    /// Quantization configuration of vector
+    quantization_config: Option<quantization_config_diff::Quantization>,
+    /// New sparse vector parameters
+    pub(crate) sparse_vectors_config: Option<Option<SparseVectorConfig>>,
+}
+
+impl UpdateCollectionBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// New configuration parameters for the collection. This operation is blocking, it will only proceed once all current optimizations are complete
+    #[allow(unused_mut)]
+    pub fn optimizers_config<VALUE: core::convert::Into<OptimizersConfigDiff>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.optimizers_config = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Wait timeout for operation commit in seconds if blocking, if not specified - default value will be supplied
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    /// New configuration parameters for the collection
+    #[allow(unused_mut)]
+    pub fn params<VALUE: core::convert::Into<CollectionParamsDiff>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.params = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// New HNSW parameters for the collection index
+    #[allow(unused_mut)]
+    pub fn hnsw_config<VALUE: core::convert::Into<HnswConfigDiff>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.hnsw_config = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// New vector parameters
+    #[allow(unused_mut)]
+    pub fn vectors_config<VALUE: core::convert::Into<VectorsConfigDiff>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.vectors_config = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Quantization configuration of vector
+    #[allow(unused_mut)]
+    pub fn quantization_config<
+        VALUE: core::convert::Into<quantization_config_diff::Quantization>,
+    >(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.quantization_config = Option::Some(value.into());
+        new
+    }
+    /// New sparse vector parameters
+    #[allow(unused_mut)]
+    pub fn sparse_vectors_config<VALUE: core::convert::Into<SparseVectorConfig>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.sparse_vectors_config = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `UpdateCollection`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<UpdateCollection, UpdateCollectionBuilderError> {
+        Ok(UpdateCollection {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            optimizers_config: match self.optimizers_config {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            params: match self.params {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            hnsw_config: match self.hnsw_config {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            vectors_config: match self.vectors_config {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            quantization_config: { convert_option(&self.quantization_config) },
+            sparse_vectors_config: match self.sparse_vectors_config {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            optimizers_config: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+            params: core::default::Default::default(),
+            hnsw_config: core::default::Default::default(),
+            vectors_config: core::default::Default::default(),
+            quantization_config: core::default::Default::default(),
+            sparse_vectors_config: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<UpdateCollectionBuilder> for UpdateCollection {
+    fn from(value: UpdateCollectionBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "UpdateCollectionBuilder", "UpdateCollection",
+        ))
+    }
+}
+
+impl UpdateCollectionBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> UpdateCollection {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "UpdateCollectionBuilder", "UpdateCollection",
+        ))
+    }
+}
+
+impl UpdateCollectionBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/update_collection_cluster_setup_request_builder.rs
+++ b/src/builders/update_collection_cluster_setup_request_builder.rs
@@ -1,0 +1,101 @@
+use crate::qdrant::*;
+
+pub struct UpdateCollectionClusterSetupRequestBuilder {
+    /// Name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+    pub(crate) timeout: Option<Option<u64>>,
+    pub(crate) operation: Option<Option<update_collection_cluster_setup_request::Operation>>,
+}
+
+impl UpdateCollectionClusterSetupRequestBuilder {
+    /// Name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Wait timeout for operation commit in seconds, if not specified - default value will be supplied
+    #[allow(unused_mut)]
+    pub fn timeout(self, value: u64) -> Self {
+        let mut new = self;
+        new.timeout = Option::Some(Option::Some(value));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn operation(
+        self,
+        value: Option<update_collection_cluster_setup_request::Operation>,
+    ) -> Self {
+        let mut new = self;
+        new.operation = Option::Some(value);
+        new
+    }
+    /**Builds a new `UpdateCollectionClusterSetupRequest`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(
+        self,
+    ) -> Result<UpdateCollectionClusterSetupRequest, UpdateCollectionClusterSetupRequestBuilderError>
+    {
+        Ok(UpdateCollectionClusterSetupRequest {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            timeout: match self.timeout {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            operation: match self.operation {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("operation"),
+                    ));
+                }
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            timeout: core::default::Default::default(),
+            operation: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<UpdateCollectionClusterSetupRequestBuilder> for UpdateCollectionClusterSetupRequest {
+    fn from(value: UpdateCollectionClusterSetupRequestBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "UpdateCollectionClusterSetupRequestBuilder", "UpdateCollectionClusterSetupRequest",
+        ))
+    }
+}
+
+impl UpdateCollectionClusterSetupRequestBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> UpdateCollectionClusterSetupRequest {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "UpdateCollectionClusterSetupRequestBuilder", "UpdateCollectionClusterSetupRequest",
+        ))
+    }
+}
+
+impl UpdateCollectionClusterSetupRequestBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/update_point_vectors_builder.rs
+++ b/src/builders/update_point_vectors_builder.rs
@@ -1,0 +1,128 @@
+use crate::qdrant::*;
+
+pub struct UpdatePointVectorsBuilder {
+    /// name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Wait until the changes have been applied?
+    pub(crate) wait: Option<Option<bool>>,
+    /// List of points and vectors to update
+    pub(crate) points: Option<Vec<PointVectors>>,
+    /// Write ordering guarantees
+    pub(crate) ordering: Option<Option<WriteOrdering>>,
+    /// Option for custom sharding to specify used shard keys
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+}
+
+impl UpdatePointVectorsBuilder {
+    /// name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Wait until the changes have been applied?
+    #[allow(unused_mut)]
+    pub fn wait(self, value: bool) -> Self {
+        let mut new = self;
+        new.wait = Option::Some(Option::Some(value));
+        new
+    }
+    /// List of points and vectors to update
+    #[allow(unused_mut)]
+    pub fn points(self, value: Vec<PointVectors>) -> Self {
+        let mut new = self;
+        new.points = Option::Some(value);
+        new
+    }
+    /// Write ordering guarantees
+    #[allow(unused_mut)]
+    pub fn ordering<VALUE: core::convert::Into<WriteOrdering>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.ordering = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Option for custom sharding to specify used shard keys
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `UpdatePointVectors`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<UpdatePointVectors, UpdatePointVectorsBuilderError> {
+        Ok(UpdatePointVectors {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            wait: match self.wait {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            points: match self.points {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("points"),
+                    ));
+                }
+            },
+            ordering: match self.ordering {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            wait: core::default::Default::default(),
+            points: core::default::Default::default(),
+            ordering: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<UpdatePointVectorsBuilder> for UpdatePointVectors {
+    fn from(value: UpdatePointVectorsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "UpdatePointVectorsBuilder", "UpdatePointVectors",
+        ))
+    }
+}
+
+impl UpdatePointVectorsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> UpdatePointVectors {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "UpdatePointVectorsBuilder", "UpdatePointVectors",
+        ))
+    }
+}
+
+impl UpdatePointVectorsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/upsert_points_builder.rs
+++ b/src/builders/upsert_points_builder.rs
@@ -1,0 +1,126 @@
+use crate::qdrant::*;
+
+pub struct UpsertPointsBuilder {
+    /// name of the collection
+    pub(crate) collection_name: Option<String>,
+    /// Wait until the changes have been applied?
+    pub(crate) wait: Option<Option<bool>>,
+    pub(crate) points: Option<Vec<PointStruct>>,
+    /// Write ordering guarantees
+    pub(crate) ordering: Option<Option<WriteOrdering>>,
+    /// Option for custom sharding to specify used shard keys
+    pub(crate) shard_key_selector: Option<Option<ShardKeySelector>>,
+}
+
+impl UpsertPointsBuilder {
+    /// name of the collection
+    #[allow(unused_mut)]
+    pub fn collection_name(self, value: String) -> Self {
+        let mut new = self;
+        new.collection_name = Option::Some(value);
+        new
+    }
+    /// Wait until the changes have been applied?
+    #[allow(unused_mut)]
+    pub fn wait(self, value: bool) -> Self {
+        let mut new = self;
+        new.wait = Option::Some(Option::Some(value));
+        new
+    }
+    #[allow(unused_mut)]
+    pub fn points(self, value: Vec<PointStruct>) -> Self {
+        let mut new = self;
+        new.points = Option::Some(value);
+        new
+    }
+    /// Write ordering guarantees
+    #[allow(unused_mut)]
+    pub fn ordering<VALUE: core::convert::Into<WriteOrdering>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.ordering = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Option for custom sharding to specify used shard keys
+    #[allow(unused_mut)]
+    pub fn shard_key_selector<VALUE: core::convert::Into<ShardKeySelector>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.shard_key_selector = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `UpsertPoints`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<UpsertPoints, UpsertPointsBuilderError> {
+        Ok(UpsertPoints {
+            collection_name: match self.collection_name {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection_name"),
+                    ));
+                }
+            },
+            wait: match self.wait {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            points: match self.points {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("points"),
+                    ));
+                }
+            },
+            ordering: match self.ordering {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            shard_key_selector: match self.shard_key_selector {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection_name: core::default::Default::default(),
+            wait: core::default::Default::default(),
+            points: core::default::Default::default(),
+            ordering: core::default::Default::default(),
+            shard_key_selector: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<UpsertPointsBuilder> for UpsertPoints {
+    fn from(value: UpsertPointsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "UpsertPointsBuilder", "UpsertPoints",
+        ))
+    }
+}
+
+impl UpsertPointsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> UpsertPoints {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "UpsertPointsBuilder", "UpsertPoints",
+        ))
+    }
+}
+
+impl UpsertPointsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/builders/uuid_index_params_builder.rs
+++ b/src/builders/uuid_index_params_builder.rs
@@ -1,0 +1,69 @@
+use crate::qdrant::*;
+
+pub struct UuidIndexParamsBuilder {
+    /// If true - used for tenant optimization.
+    pub(crate) is_tenant: Option<Option<bool>>,
+    /// If true - store index on disk.
+    pub(crate) on_disk: Option<Option<bool>>,
+}
+
+impl UuidIndexParamsBuilder {
+    /// If true - used for tenant optimization.
+    #[allow(unused_mut)]
+    pub fn is_tenant(self, value: bool) -> Self {
+        let mut new = self;
+        new.is_tenant = Option::Some(Option::Some(value));
+        new
+    }
+    /// If true - store index on disk.
+    #[allow(unused_mut)]
+    pub fn on_disk(self, value: bool) -> Self {
+        let mut new = self;
+        new.on_disk = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `UuidIndexParams`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<UuidIndexParams, std::convert::Infallible> {
+        Ok(UuidIndexParams {
+            is_tenant: match self.is_tenant {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            on_disk: match self.on_disk {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            is_tenant: core::default::Default::default(),
+            on_disk: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<UuidIndexParamsBuilder> for UuidIndexParams {
+    fn from(value: UuidIndexParamsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "UuidIndexParamsBuilder", "UuidIndexParams",
+        ))
+    }
+}
+
+impl UuidIndexParamsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> UuidIndexParams {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "UuidIndexParamsBuilder", "UuidIndexParams",
+        ))
+    }
+}

--- a/src/builders/vector_params_builder.rs
+++ b/src/builders/vector_params_builder.rs
@@ -1,0 +1,210 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct VectorParamsBuilder {
+    /// Size of the vectors
+    pub(crate) size: Option<u64>,
+    /// Distance function used for comparing vectors
+    pub(crate) distance: Option<i32>,
+    /// Configuration of vector HNSW graph. If omitted - the collection configuration will be used
+    pub(crate) hnsw_config: Option<Option<HnswConfigDiff>>,
+    /// Configuration of vector quantization config. If omitted - the collection configuration will be used
+    quantization_config: Option<quantization_config::Quantization>,
+    /// If true - serve vectors from disk. If set to false, the vectors will be loaded in RAM.
+    pub(crate) on_disk: Option<Option<bool>>,
+    /// Data type of the vectors
+    pub(crate) datatype: Option<Option<i32>>,
+    /// Configuration for multi-vector search
+    pub(crate) multivector_config: Option<Option<MultiVectorConfig>>,
+}
+
+impl VectorParamsBuilder {
+    /// Size of the vectors
+    #[allow(unused_mut)]
+    pub fn size(self, value: u64) -> Self {
+        let mut new = self;
+        new.size = Option::Some(value);
+        new
+    }
+    /// Distance function used for comparing vectors
+    #[allow(unused_mut)]
+    pub fn distance<VALUE: core::convert::Into<i32>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.distance = Option::Some(value.into());
+        new
+    }
+    /// Configuration of vector HNSW graph. If omitted - the collection configuration will be used
+    #[allow(unused_mut)]
+    pub fn hnsw_config<VALUE: core::convert::Into<HnswConfigDiff>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.hnsw_config = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Configuration of vector quantization config. If omitted - the collection configuration will be used
+    #[allow(unused_mut)]
+    pub fn quantization_config<VALUE: core::convert::Into<quantization_config::Quantization>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.quantization_config = Option::Some(value.into());
+        new
+    }
+    /// If true - serve vectors from disk. If set to false, the vectors will be loaded in RAM.
+    #[allow(unused_mut)]
+    pub fn on_disk(self, value: bool) -> Self {
+        let mut new = self;
+        new.on_disk = Option::Some(Option::Some(value));
+        new
+    }
+    /// Data type of the vectors
+    #[allow(unused_mut)]
+    pub fn datatype<VALUE: core::convert::Into<i32>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.datatype = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Configuration for multi-vector search
+    #[allow(unused_mut)]
+    pub fn multivector_config<VALUE: core::convert::Into<MultiVectorConfig>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.multivector_config = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `VectorParams`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<VectorParams, VectorParamsBuilderError> {
+        Ok(VectorParams {
+            size: match self.size {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            distance: match self.distance {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            hnsw_config: match self.hnsw_config {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            quantization_config: { convert_option(&self.quantization_config) },
+            on_disk: match self.on_disk {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            datatype: match self.datatype {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            multivector_config: match self.multivector_config {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            size: core::default::Default::default(),
+            distance: core::default::Default::default(),
+            hnsw_config: core::default::Default::default(),
+            quantization_config: core::default::Default::default(),
+            on_disk: core::default::Default::default(),
+            datatype: core::default::Default::default(),
+            multivector_config: core::default::Default::default(),
+        }
+    }
+}
+
+impl SparseVectorParamsBuilder {
+    /// Configuration of sparse index
+    #[allow(unused_mut)]
+    pub fn index<VALUE: core::convert::Into<SparseIndexConfig>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.index = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// If set - apply modifier to the vector values
+    #[allow(unused_mut)]
+    pub fn modifier<VALUE: core::convert::Into<i32>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.modifier = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /**Builds a new `SparseVectorParams`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<SparseVectorParams, std::convert::Infallible> {
+        Ok(SparseVectorParams {
+            index: match self.index {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            modifier: match self.modifier {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            index: core::default::Default::default(),
+            modifier: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<VectorParamsBuilder> for VectorParams {
+    fn from(value: VectorParamsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "VectorParamsBuilder", "VectorParams",
+        ))
+    }
+}
+
+impl VectorParamsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> VectorParams {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "VectorParamsBuilder", "VectorParams",
+        ))
+    }
+}
+
+impl VectorParamsBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}
+
+impl From<SparseVectorParamsBuilder> for SparseVectorParams {
+    fn from(value: SparseVectorParamsBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "SparseVectorParamsBuilder", "SparseVectorParams",
+        ))
+    }
+}
+
+impl SparseVectorParamsBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> SparseVectorParams {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "SparseVectorParamsBuilder", "SparseVectorParams",
+        ))
+    }
+}

--- a/src/builders/vector_params_diff_builder.rs
+++ b/src/builders/vector_params_diff_builder.rs
@@ -1,0 +1,86 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct VectorParamsDiffBuilder {
+    /// Update params for HNSW index. If empty object - it will be unset
+    pub(crate) hnsw_config: Option<Option<HnswConfigDiff>>,
+    /// Update quantization params. If none - it is left unchanged.
+    quantization_config: Option<quantization_config_diff::Quantization>,
+    /// If true - serve vectors from disk. If set to false, the vectors will be loaded in RAM.
+    pub(crate) on_disk: Option<Option<bool>>,
+}
+
+impl VectorParamsDiffBuilder {
+    /// Update params for HNSW index. If empty object - it will be unset
+    #[allow(unused_mut)]
+    pub fn hnsw_config<VALUE: core::convert::Into<HnswConfigDiff>>(self, value: VALUE) -> Self {
+        let mut new = self;
+        new.hnsw_config = Option::Some(Option::Some(value.into()));
+        new
+    }
+    /// Update quantization params. If none - it is left unchanged.
+    #[allow(unused_mut)]
+    pub fn quantization_config<
+        VALUE: core::convert::Into<quantization_config_diff::Quantization>,
+    >(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.quantization_config = Option::Some(value.into());
+        new
+    }
+    /// If true - serve vectors from disk. If set to false, the vectors will be loaded in RAM.
+    #[allow(unused_mut)]
+    pub fn on_disk(self, value: bool) -> Self {
+        let mut new = self;
+        new.on_disk = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `VectorParamsDiff`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<VectorParamsDiff, std::convert::Infallible> {
+        Ok(VectorParamsDiff {
+            hnsw_config: match self.hnsw_config {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            quantization_config: { convert_option(&self.quantization_config) },
+            on_disk: match self.on_disk {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            hnsw_config: core::default::Default::default(),
+            quantization_config: core::default::Default::default(),
+            on_disk: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<VectorParamsDiffBuilder> for VectorParamsDiff {
+    fn from(value: VectorParamsDiffBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "VectorParamsDiffBuilder", "VectorParamsDiff",
+        ))
+    }
+}
+
+impl VectorParamsDiffBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> VectorParamsDiff {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "VectorParamsDiffBuilder", "VectorParamsDiff",
+        ))
+    }
+}

--- a/src/builders/wal_config_diff_builder.rs
+++ b/src/builders/wal_config_diff_builder.rs
@@ -1,0 +1,69 @@
+use crate::qdrant::*;
+
+pub struct WalConfigDiffBuilder {
+    /// Size of a single WAL block file
+    pub(crate) wal_capacity_mb: Option<Option<u64>>,
+    /// Number of segments to create in advance
+    pub(crate) wal_segments_ahead: Option<Option<u64>>,
+}
+
+impl WalConfigDiffBuilder {
+    /// Size of a single WAL block file
+    #[allow(unused_mut)]
+    pub fn wal_capacity_mb(self, value: u64) -> Self {
+        let mut new = self;
+        new.wal_capacity_mb = Option::Some(Option::Some(value));
+        new
+    }
+    /// Number of segments to create in advance
+    #[allow(unused_mut)]
+    pub fn wal_segments_ahead(self, value: u64) -> Self {
+        let mut new = self;
+        new.wal_segments_ahead = Option::Some(Option::Some(value));
+        new
+    }
+    /**Builds a new `WalConfigDiff`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<WalConfigDiff, std::convert::Infallible> {
+        Ok(WalConfigDiff {
+            wal_capacity_mb: match self.wal_capacity_mb {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+            wal_segments_ahead: match self.wal_segments_ahead {
+                Some(value) => value,
+                None => core::default::Default::default(),
+            },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            wal_capacity_mb: core::default::Default::default(),
+            wal_segments_ahead: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<WalConfigDiffBuilder> for WalConfigDiff {
+    fn from(value: WalConfigDiffBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "WalConfigDiffBuilder", "WalConfigDiff",
+        ))
+    }
+}
+
+impl WalConfigDiffBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> WalConfigDiff {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "WalConfigDiffBuilder", "WalConfigDiff",
+        ))
+    }
+}

--- a/src/builders/with_lookup_builder.rs
+++ b/src/builders/with_lookup_builder.rs
@@ -1,0 +1,94 @@
+use crate::grpc_macros::convert_option;
+use crate::qdrant::*;
+
+pub struct WithLookupBuilder {
+    /// Name of the collection to use for points lookup
+    pub(crate) collection: Option<String>,
+    /// Options for specifying which payload to include (or not)
+    with_payload: Option<with_payload_selector::SelectorOptions>,
+    /// Options for specifying which vectors to include (or not)
+    with_vectors: Option<with_vectors_selector::SelectorOptions>,
+}
+
+impl WithLookupBuilder {
+    /// Name of the collection to use for points lookup
+    #[allow(unused_mut)]
+    pub fn collection(self, value: String) -> Self {
+        let mut new = self;
+        new.collection = Option::Some(value);
+        new
+    }
+    /// Options for specifying which payload to include (or not)
+    #[allow(unused_mut)]
+    pub fn with_payload<VALUE: core::convert::Into<with_payload_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_payload = Option::Some(value.into());
+        new
+    }
+    /// Options for specifying which vectors to include (or not)
+    #[allow(unused_mut)]
+    pub fn with_vectors<VALUE: core::convert::Into<with_vectors_selector::SelectorOptions>>(
+        self,
+        value: VALUE,
+    ) -> Self {
+        let mut new = self;
+        new.with_vectors = Option::Some(value.into());
+        new
+    }
+    /**Builds a new `WithLookup`.
+
+    # Errors
+
+    If a required field has not been initialized.
+    */
+    fn build_inner(self) -> Result<WithLookup, WithLookupBuilderError> {
+        Ok(WithLookup {
+            collection: match self.collection {
+                Some(value) => value,
+                None => {
+                    return Result::Err(core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from("collection"),
+                    ));
+                }
+            },
+            with_payload: { convert_option(&self.with_payload) },
+            with_vectors: { convert_option(&self.with_vectors) },
+        })
+    }
+    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+    fn create_empty() -> Self {
+        Self {
+            collection: core::default::Default::default(),
+            with_payload: core::default::Default::default(),
+            with_vectors: core::default::Default::default(),
+        }
+    }
+}
+
+impl From<WithLookupBuilder> for WithLookup {
+    fn from(value: WithLookupBuilder) -> Self {
+        value.build_inner().expect(&format!(
+            "Failed to convert {0} to {1}",
+            "WithLookupBuilder", "WithLookup",
+        ))
+    }
+}
+
+impl WithLookupBuilder {
+    /// Builds the desired type. Can often be omitted.
+    pub fn build(self) -> WithLookup {
+        self.build_inner().expect(&format!(
+            "Failed to build {0} into {1}",
+            "WithLookupBuilder", "WithLookup",
+        ))
+    }
+}
+
+impl WithLookupBuilder {
+    pub(crate) fn empty() -> Self {
+        Self::create_empty()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ pub mod qdrant;
 mod auth;
 mod builder_ext;
 mod builder_types;
+pub mod builders;
 mod channel_pool;
 mod filters;
 mod grpc_conversions;
@@ -138,7 +139,6 @@ mod grpc_macros;
 mod manual_builder;
 mod payload;
 mod qdrant_client;
-
 // Deprecated modules
 /// Deprecated Qdrant client
 #[deprecated(
@@ -180,13 +180,14 @@ pub mod config {
 mod tests {
     use std::collections::HashMap;
 
+    use crate::builders::CreateCollectionBuilder;
     use crate::payload::Payload;
     use crate::qdrant::value::Kind::*;
     use crate::qdrant::{
-        Condition, CreateCollectionBuilder, CreateFieldIndexCollection, DeletePayloadPointsBuilder,
-        DeletePointsBuilder, Distance, FieldType, Filter, GetPointsBuilder, ListValue, PointStruct,
-        SearchPointsBuilder, SetPayloadPointsBuilder, SnapshotDownloadBuilder, Struct,
-        UpsertPointsBuilder, Value, VectorParamsBuilder,
+        Condition, CreateFieldIndexCollection, DeletePayloadPointsBuilder, DeletePointsBuilder,
+        Distance, FieldType, Filter, GetPointsBuilder, ListValue, PointStruct, SearchPointsBuilder,
+        SetPayloadPointsBuilder, SnapshotDownloadBuilder, Struct, UpsertPointsBuilder, Value,
+        VectorParamsBuilder,
     };
     use crate::Qdrant;
 

--- a/src/qdrant_client/collection.rs
+++ b/src/qdrant_client/collection.rs
@@ -435,10 +435,11 @@ mod tests {
     use tokio::time::sleep;
 
     use super::*;
+    use crate::builders::CreateCollectionBuilder;
     use crate::payload::Payload;
     use crate::qdrant::{
-        CountPointsBuilder, CreateCollectionBuilder, Distance, PointStruct, SearchPointsBuilder,
-        UpsertPointsBuilder, VectorParamsBuilder,
+        CountPointsBuilder, Distance, PointStruct, SearchPointsBuilder, UpsertPointsBuilder,
+        VectorParamsBuilder,
     };
 
     #[tokio::test]

--- a/src/qdrant_client/query.rs
+++ b/src/qdrant_client/query.rs
@@ -133,13 +133,14 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+    use crate::builders::CreateCollectionBuilder;
     use crate::qdrant::{
-        ContextInputBuilder, CreateCollectionBuilder, CreateFieldIndexCollectionBuilder, Datatype,
-        DiscoverInputBuilder, Distance, FieldType, Fusion, IntegerIndexParamsBuilder, Modifier,
-        MultiVectorConfig, NamedVectors, PointId, PointStruct, PrefetchQueryBuilder, Query,
-        QueryPointsBuilder, RecommendInputBuilder, ScalarQuantizationBuilder,
-        SparseIndexConfigBuilder, SparseVectorParamsBuilder, SparseVectorsConfigBuilder,
-        UpsertPointsBuilder, Vector, VectorInput, VectorParamsBuilder, VectorsConfigBuilder,
+        ContextInputBuilder, CreateFieldIndexCollectionBuilder, Datatype, DiscoverInputBuilder,
+        Distance, FieldType, Fusion, IntegerIndexParamsBuilder, Modifier, MultiVectorConfig,
+        NamedVectors, PointId, PointStruct, PrefetchQueryBuilder, Query, QueryPointsBuilder,
+        RecommendInputBuilder, ScalarQuantizationBuilder, SparseIndexConfigBuilder,
+        SparseVectorParamsBuilder, SparseVectorsConfigBuilder, UpsertPointsBuilder, Vector,
+        VectorInput, VectorParamsBuilder, VectorsConfigBuilder,
     };
     use crate::Payload;
 

--- a/tests/snippet_tests/test_create_collection.rs
+++ b/tests/snippet_tests/test_create_collection.rs
@@ -4,7 +4,8 @@ async fn test_create_collection() {
     async fn create_collection() -> Result<(), Box<dyn std::error::Error>> {
       // WARNING: This is a generated test snippet.
       // Please, modify the snippet in the `../snippets/create_collection.rs` file
-        use qdrant_client::qdrant::{CreateCollectionBuilder, Distance, VectorParamsBuilder};
+        use qdrant_client::qdrant::{Distance, VectorParamsBuilder};
+        use qdrant_client::builders::CreateCollectionBuilder;
         use qdrant_client::Qdrant;
         
         let client = Qdrant::from_url("http://localhost:6334").build()?;

--- a/tests/snippets/create_collection.rs
+++ b/tests/snippets/create_collection.rs
@@ -1,4 +1,5 @@
-use qdrant_client::qdrant::{CreateCollectionBuilder, Distance, VectorParamsBuilder};
+use qdrant_client::qdrant::{Distance, VectorParamsBuilder};
+use qdrant_client::builders::CreateCollectionBuilder;
 use qdrant_client::Qdrant;
 
 let client = Qdrant::from_url("http://localhost:6334").build()?;


### PR DESCRIPTION
Fixes: #195

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
Apologies, i just saw this, should I try to cherry pick this commit into a new branch checked out from dev and make a new PR?
* [ ] Have you followed the guidelines in our Contributing document?
I didn't find any Contributing.md or any instructions in the README.md hence the goof up with the branch checkout
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
yes there is one but that seems to be following the wrong approach of handwriting all the unrolled macros

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?


closes https://github.com/qdrant/rust-client/issues/195
/claim https://github.com/qdrant/rust-client/issues/195