### PR TITLE
Send client and rust version to server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ reqwest = { version = "0.12.8", optional = true, default-features = false, featu
 futures-util = { version = "0.3.31", optional = true }
 derive_builder = { version = "0.20.2" }
 thiserror = "1.0.64"
+rustc_version = "0.4"
 
 [dev-dependencies]
 tonic-build = { version = "0.12.3", features = ["prost"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,7 @@ mod grpc_macros;
 mod manual_builder;
 mod payload;
 mod qdrant_client;
+mod user_agent;
 // Deprecated modules
 /// Deprecated Qdrant client
 #[deprecated(

--- a/src/user_agent.rs
+++ b/src/user_agent.rs
@@ -1,0 +1,46 @@
+use rustc_version::version_meta;
+use tonic::service::Interceptor;
+use tonic::{Request, Status};
+
+pub struct UserAgentInterceptor {
+    rust_version: Option<String>,
+    rust_client_version: Option<String>,
+}
+
+impl Default for UserAgentInterceptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UserAgentInterceptor {
+    pub fn new() -> Self {
+        let rust_version = Some(version_meta().unwrap().semver.to_string());
+        let rust_client_version = Some(env!("CARGO_PKG_VERSION").to_string());
+
+        Self {
+            rust_version,
+            rust_client_version,
+        }
+    }
+}
+
+impl Interceptor for UserAgentInterceptor {
+    fn call(&mut self, mut req: Request<()>) -> Result<Request<()>, Status> {
+        let user_agent_value = format!(
+            "rust-client/{} rust/{}",
+            self.rust_version.clone().unwrap_or_default(),
+            self.rust_client_version.clone().unwrap_or_default()
+        );
+        req.metadata_mut().insert(
+            "x-user-agent",
+            user_agent_value.parse().map_err(|_| {
+                Status::invalid_argument(format!(
+                    "Malformed user-agent value: {}",
+                    user_agent_value
+                ))
+            })?,
+        );
+        Ok(req)
+    }
+}


### PR DESCRIPTION
* Add a new interceptor to inject a header on each request.
* Introduce a new request header with info about client and rust versions: `x-user-agent`. 
* Introduce a new dependency `rustc_version` to fetch Rust version.

Note: I had to add a new header instead of using user-agent, as tokio seems to replace user-agent with its own value.

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [X] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [X] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
