### PR TITLE
Bump dev version to `1.13.0-dev`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant-client"
-version = "1.6.0"
+version = "1.13.0-dev"
 edition = "2021"
 authors = ["Qdrant Team <team@qdrant.com>"]
 description = "Rust client for Qdrant Vector Search Engine"


### PR DESCRIPTION
We had a lagging `dev` version of the client, which caused that `dev` bfb started showing client-server incompatibility messages.

This also makes it consistent with qdrant repo itself.