### PR TITLE
Print metadata for error response display

### DIFF
--- a/src/qdrant_client/error.rs
+++ b/src/qdrant_client/error.rs
@@ -5,7 +5,7 @@ use tonic::codegen::http::uri::InvalidUri;
 #[derive(Error, Debug)]
 pub enum QdrantError {
     /// Qdrant server responded with an error
-    #[error("Error in the response: {} {}", .status.code(), .status.message())]
+    #[error("Error in the response: {} {} {:?}", .status.code(), .status.message(), .status.metadata())]
     ResponseError {
         /// gRPC status code
         status: tonic::Status,


### PR DESCRIPTION
Additional information can be present in the response `metadata` so it makes sense to always display it in case of error to ease debugging. 