### PR TITLE
Disable tonic default features who introduces outdated axum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["database", "api-bindings"]
 keywords = ["qdrant", "vector-search", "search-engine", "client", "grpc"]
 
 [dependencies]
-tonic = { version = "0.12.3", features = ["tls", "tls-roots", "gzip"] }
+tonic = { version = "0.12.3", default-features = false, features = ["codegen", "prost", "tls", "tls-roots", "gzip"] }
 prost = "0.13.3"
 prost-types = "0.13.3"
 anyhow = "1.0.89"


### PR DESCRIPTION
This is to avoid having to introduce indirect dependency of axum, which is often not the latest if fron `tonic->tower->axum`.

Say if a downstream project which is a http web server based on axum, but they don't need grpc so as to tonic so they have the latest version of axum(v0.8 as of now). However as `qdrant-client` depends on tonic thus tower->axum(v0.7), the end project will have two axum dependency.

Anyway I think that we don't need server features as a client after all.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [ ] ~~Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?~~
3. [ ] ~~Have you checked your code using `cargo clippy --all --all-features` command?~~

