### PR TITLE
Construct point ID from UUID

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ futures-util = { version = "0.3.31", optional = true }
 derive_builder = { version = "0.20.2" }
 thiserror = "1.0.64"
 semver = "1.0.24"
+uuid = { version = "1.8.2", optional = true }
 
 [dev-dependencies]
 tonic-build = { version = "0.12.3", features = ["prost"] }
@@ -35,6 +36,7 @@ default = ["download_snapshots", "serde", "generate-snippets"]
 download_snapshots = ["reqwest", "futures-util"]
 serde = ["dep:serde", "dep:serde_json"]
 generate-snippets = []
+uuid = ["dep:uuid"]
 
 [[example]]
 name = "search"

--- a/src/grpc_conversions/extensions.rs
+++ b/src/grpc_conversions/extensions.rs
@@ -1,10 +1,15 @@
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 
+#[cfg(feature = "uuid")]
+use uuid::Uuid;
+
 use crate::client::Payload;
 #[allow(deprecated)]
 use crate::error::NotA;
 use crate::prelude::{PointStruct, Value};
+#[cfg(feature = "uuid")]
+use crate::qdrant::point_id::PointIdOptions;
 use crate::qdrant::value::Kind;
 use crate::qdrant::{
     HardwareUsage, ListValue, PointId, RetrievedPoint, ScoredPoint, Struct, Vectors,
@@ -294,6 +299,22 @@ impl IntoIterator for ListValue {
 impl ListValue {
     pub fn iter(&self) -> std::slice::Iter<'_, Value> {
         self.values.iter()
+    }
+}
+
+#[cfg(feature = "uuid")]
+impl From<Uuid> for PointId {
+    fn from(uuid: Uuid) -> Self {
+        Self {
+            point_id_options: Some(PointIdOptions::from(uuid)),
+        }
+    }
+}
+
+#[cfg(feature = "uuid")]
+impl From<Uuid> for PointIdOptions {
+    fn from(uuid: Uuid) -> Self {
+        PointIdOptions::Uuid(uuid.to_string())
     }
 }
 


### PR DESCRIPTION
Fixes <https://github.com/qdrant/rust-client/issues/225>

Allows `PointId::from(uuid)` and `PointStruct::new(uuid, ...)` as requested [here](https://github.com/qdrant/rust-client/issues/225#issuecomment-2993211346).

Because we normally don't depend on `uuid` in our Rust crate, I've added it as optional dependency. Users can enable it as they please.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?