### PR TITLE
Derive Clone on Qdrant client

### DIFF
--- a/src/qdrant_client/mod.rs
+++ b/src/qdrant_client/mod.rs
@@ -153,7 +153,10 @@ impl Qdrant {
             config.keep_alive_while_idle,
         );
 
-        let client = Self { channel: Arc::new(channel), config };
+        let client = Self {
+            channel: Arc::new(channel),
+            config,
+        };
 
         Ok(client)
     }


### PR DESCRIPTION
Fixes <https://github.com/qdrant/rust-client/issues/229>

Makes the client [`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html), as it is common in other clients too.

It wraps the internal channel pool in an `Arc`.

Ideally we'd `Arc` the configuration too. But, it is exposed, and doing so will change the API interface people might already rely on. Just cloning the channel pool is probably a good enough compromise.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?