### PR TITLE
Fix clippy warnings for Rust 1.91

### DIFF
--- a/src/qdrant_client/builders/vectors.rs
+++ b/src/qdrant_client/builders/vectors.rs
@@ -75,7 +75,7 @@ impl Vector {
 
         let vectors_count = self.vectors_count.unwrap();
 
-        if self.data.len() % vectors_count as usize != 0 {
+        if !self.data.len().is_multiple_of(vectors_count as usize) {
             return Err(QdrantError::ConversionError(format!(
                 "Malformed multi vector: data length {} is not divisible by vectors count {}",
                 self.data.len(),

--- a/src/serde_deser.rs
+++ b/src/serde_deser.rs
@@ -475,7 +475,8 @@ mod test {
     use serde::{Deserialize, Serialize};
     use serde_json::json;
 
-    use crate::{serde_deser::DeserPayloadError, Payload};
+    use crate::serde_deser::DeserPayloadError;
+    use crate::Payload;
 
     #[test]
     fn test_json_deser() {


### PR DESCRIPTION
```
error: manual implementation of `.is_multiple_of()`
  --> src/qdrant_client/builders/vectors.rs:78:12
   |
78 |         if self.data.len() % vectors_count as usize != 0 {
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `!self.data.len().is_multiple_of(vectors_count as usize)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#manual_is_multiple_of
   = note: `-D clippy::manual-is-multiple-of` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::manual_is_multiple_of)]`

error: could not compile `qdrant-client` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `qdrant-client` (lib test) due to 1 previous error
```

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?