### PR TITLE
Bump dev version to 1.16.1-dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant-client"
-version = "1.14.1-dev"
+version = "1.16.1-dev"
 edition = "2021"
 authors = ["Qdrant Team <team@qdrant.com>"]
 description = "Rust client for Qdrant Vector Search Engine"


### PR DESCRIPTION
Follows the pattern of <https://github.com/qdrant/rust-client/pull/220>

#### Tasks
- [x] Release Qdrant 1.16.0 (<https://github.com/qdrant/rust-client/pull/248>)