### PR TITLE
feat: add connect method to verify gRPC connectivity

### DIFF
--- a/src/channel_pool.rs
+++ b/src/channel_pool.rs
@@ -154,6 +154,13 @@ impl ChannelPool {
             0
         }
     }
+
+    /// Explicitly establishes a connection to at least one channel in the pool.
+    /// This triggers the underlying gRPC handshake.
+    pub async fn connect(&self) -> Result<(), Status> {
+        let _ = self.get_channel().await?;
+        Ok(())
+    }
 }
 
 // The future returned by get_channel needs to be Send so that the client can be

--- a/src/qdrant_client/mod.rs
+++ b/src/qdrant_client/mod.rs
@@ -229,4 +229,12 @@ impl Qdrant {
         })
         .await
     }
+
+    /// Performs a connectivity check to the Qdrant server.
+    ///
+    /// This method forces the client to establish a connection immediately.
+    /// Returns an error if the TCP connection or gRPC handshake fails.
+    pub async fn connect(&self) -> QdrantResult<()> {
+        self.channel.connect().await.map_err(Into::into)
+    }
 }

--- a/tests/snippet_tests/mod.rs
+++ b/tests/snippet_tests/mod.rs
@@ -1,6 +1,7 @@
 mod test_batch_update;
 mod test_clear_payload;
 mod test_collection_exists;
+mod test_connect;
 mod test_count_points;
 mod test_create_collection;
 mod test_create_collection_with_bq;

--- a/tests/snippet_tests/test_connect.rs
+++ b/tests/snippet_tests/test_connect.rs
@@ -1,0 +1,20 @@
+
+#[tokio::test]
+async fn test_connect() {
+    async fn connect() -> Result<(), Box<dyn std::error::Error>> {
+      // WARNING: This is a generated test snippet.
+      // Please, modify the snippet in the `../snippets/connect.rs` file
+        use qdrant_client::Qdrant;
+        use std::time::Duration;
+        
+        let client = Qdrant::from_url("http://localhost:1234")
+            .connect_timeout(Duration::from_millis(500))
+            .build()?;
+        
+        let connection_result = client.connect().await;
+        
+        assert!(connection_result.is_err());
+        Ok(())
+    }
+    let _ = connect().await;
+}

--- a/tests/snippet_tests/test_verify_connection_failure.rs
+++ b/tests/snippet_tests/test_verify_connection_failure.rs
@@ -1,0 +1,28 @@
+
+#[tokio::test]
+async fn test_verify_connection_failure() {
+    async fn verify_connection_failure() -> Result<(), Box<dyn std::error::Error>> {
+      // WARNING: This is a generated test snippet.
+      // Please, modify the snippet in the `../snippets/verify_connection_failure.rs` file
+        #[tokio::test]
+        async fn test_verify_connection_failure() {
+            use crate::qdrant_client::Qdrant;
+        
+            // We use an address that doesn't respond
+            let client = Qdrant::from_url("http://127.0.0.1:1234")
+                .connect_timeout(std::time::Duration::from_millis(500))
+                .build()
+                .unwrap();
+        
+            // build() always succeeds (lazy behavior),
+            // but connect() should detect the failure.
+            let result = client.connect().await;
+            assert!(
+                result.is_err(),
+                "The connection should have failed on an invalid port"
+            );
+        }
+        Ok(())
+    }
+    let _ = verify_connection_failure().await;
+}

--- a/tests/snippets/connect.rs
+++ b/tests/snippets/connect.rs
@@ -1,0 +1,10 @@
+use qdrant_client::Qdrant;
+use std::time::Duration;
+
+let client = Qdrant::from_url("http://localhost:1234")
+    .connect_timeout(Duration::from_millis(500))
+    .build()?;
+
+let connection_result = client.connect().await;
+
+assert!(connection_result.is_err());


### PR DESCRIPTION
This PR resolves issue #258 where the `Qdrant` client was successfully built even if the server was unreachable due to the "lazy" nature of gRPC channels.
**Changes:**
* Added `connect()` method in `ChannelPool` to explicitly trigger `make_channel()` and the underlying Tonic connection.
* Exposed `pub async fn connect(&self)` in the `Qdrant` client for users to eagerly verify connectivity.
* Added an integration test snippet in `tests/snippets/connect.rs` to verify that `connect()` correctly returns an error on invalid URLs.

#### All Submissions:

* [x] Contributions should target the `dev` branch.
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests?

#### New Feature Submissions:

1. [x] Does your submission pass tests? (Verified locally)
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all`?
3. [x] Have you checked your code using `cargo clippy --all --all-features`?

#### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why?
* [x] Have you written new tests for your core changes?
* [x] Have you successfully ran tests with your changes locally?