### PR TITLE
feat: add user defined interceptors

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,6 +1,7 @@
 use tonic::service::Interceptor;
 use tonic::{Request, Status};
 
+#[derive(Clone)]
 pub struct TokenInterceptor {
     api_key: Option<String>,
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -25,3 +25,31 @@ impl Interceptor for TokenInterceptor {
         Ok(req)
     }
 }
+
+#[derive(Clone)]
+pub struct WrappedInterceptor<I: Send + Sync + 'static + Clone + Interceptor = TokenInterceptor> {
+    pub inner: Option<I>,
+}
+
+impl<I: Send + Sync + 'static + Clone + Interceptor> Default for WrappedInterceptor<I> {
+    fn default() -> Self {
+        Self { inner: None }
+    }
+}
+
+impl<I: Send + Sync + 'static + Clone + Interceptor> WrappedInterceptor<I> {
+    pub fn new(interceptor: I) -> Self {
+        Self {
+            inner: Some(interceptor),
+        }
+    }
+}
+
+impl<I: Send + Sync + 'static + Clone + Interceptor> Interceptor for WrappedInterceptor<I> {
+    fn call(&mut self, req: Request<()>) -> anyhow::Result<Request<()>, Status> {
+        match self.inner.as_mut() {
+            Some(inter) => inter.call(req),
+            None => Ok(req),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,12 +153,12 @@ pub mod serde_deser;
 // Re-exports
 pub use crate::payload::Payload;
 pub use crate::qdrant_client::error::QdrantError;
-pub use crate::qdrant_client::{Qdrant, QdrantBuilder};
+pub use crate::qdrant_client::{GenericQdrant, Qdrant, QdrantBuilder};
 
 /// Client configuration
 pub mod config {
     pub use crate::qdrant_client::config::{
-        AsOptionApiKey, AsTimeout, CompressionEncoding, QdrantConfig,
+        AsOptionApiKey, AsTimeout, CompressionEncoding, GenericQdrantConfig, QdrantConfig,
     };
 }
 

--- a/src/qdrant_client/config.rs
+++ b/src/qdrant_client/config.rs
@@ -6,6 +6,8 @@ use crate::auth::{TokenInterceptor, WrappedInterceptor};
 use crate::qdrant_client::GenericQdrant;
 use crate::QdrantError;
 
+pub type QdrantConfig = GenericQdrantConfig<TokenInterceptor>;
+
 struct DefaultConfigValues<I: Send + Sync + 'static + Clone + Interceptor = TokenInterceptor> {
     timeout: Duration,
     connect_timeout: Duration,
@@ -45,7 +47,7 @@ impl<I: Send + Sync + 'static + Clone + Interceptor> Default for DefaultConfigVa
 ///     .build();
 /// ```
 #[derive(Clone)]
-pub struct QdrantConfig<I: Send + Sync + 'static + Clone + Interceptor = TokenInterceptor> {
+pub struct GenericQdrantConfig<I: Send + Sync + 'static + Clone + Interceptor = TokenInterceptor> {
     /// Qdrant server URI to connect to
     pub uri: String,
 
@@ -72,7 +74,7 @@ pub struct QdrantConfig<I: Send + Sync + 'static + Clone + Interceptor = TokenIn
     pub interceptor: WrappedInterceptor<I>,
 }
 
-impl<I: Send + Sync + 'static + Clone + Interceptor> QdrantConfig<I> {
+impl<I: Send + Sync + 'static + Clone + Interceptor> GenericQdrantConfig<I> {
     fn with_defaults(url: &str) -> Self {
         let defaults = DefaultConfigValues::default();
         Self {
@@ -151,9 +153,9 @@ impl<I: Send + Sync + 'static + Clone + Interceptor> QdrantConfig<I> {
     /// Set the interceptor to use for this client
     ///
     /// ```no_run
-    /// use qdrant_client::GenericQdrant;
-    /// use tonic::service::Interceptor;
-    /// use tonic::{Request, Status};
+    ///# use qdrant_client::GenericQdrant;
+    ///# use tonic::service::Interceptor;
+    ///# use tonic::{Request, Status};
     ///
     /// #[derive(Clone)]
     /// struct CustomInterceptor;
@@ -164,7 +166,7 @@ impl<I: Send + Sync + 'static + Clone + Interceptor> QdrantConfig<I> {
     /// }
     ///
     ///# async fn connect() -> Result<(), qdrant_client::QdrantError> {
-    /// let client = GenericQdrant<CustomInterceptor>::from_url("http://localhost:6334")
+    /// let client = GenericQdrant::<CustomInterceptor>::from_url("http://localhost:6334")
     /// .interceptor(CustomInterceptor)
     /// .build()?;
     ///# Ok(())
@@ -227,7 +229,7 @@ impl<I: Send + Sync + 'static + Clone + Interceptor> QdrantConfig<I> {
     }
 }
 
-impl QdrantConfig<TokenInterceptor> {
+impl GenericQdrantConfig<TokenInterceptor> {
     /// Set an optional API key
     ///
     /// This method is only available when using the default TokenInterceptor.
@@ -259,7 +261,7 @@ impl QdrantConfig<TokenInterceptor> {
 /// Default Qdrant client configuration.
 ///
 /// Connects to `http://localhost:6334` without an API key.
-impl Default for QdrantConfig<TokenInterceptor> {
+impl Default for GenericQdrantConfig<TokenInterceptor> {
     fn default() -> Self {
         Self::with_defaults("http://localhost:6334")
     }

--- a/src/qdrant_client/config.rs
+++ b/src/qdrant_client/config.rs
@@ -2,18 +2,21 @@ use std::time::Duration;
 
 use tonic::service::Interceptor;
 
-use crate::{auth::TokenInterceptor, Qdrant, QdrantError};
+use crate::auth::{TokenInterceptor, WrappedInterceptor};
+use crate::qdrant_client::GenericQdrant;
+use crate::QdrantError;
 
-struct DefaultConfigValues {
+struct DefaultConfigValues<I: Send + Sync + 'static + Clone + Interceptor = TokenInterceptor> {
     timeout: Duration,
     connect_timeout: Duration,
     keep_alive_while_idle: bool,
     compression: Option<CompressionEncoding>,
     check_compatibility: bool,
     pool_size: usize,
+    interceptor: WrappedInterceptor<I>,
 }
 
-impl Default for DefaultConfigValues {
+impl<I: Send + Sync + 'static + Clone + Interceptor> Default for DefaultConfigValues<I> {
     fn default() -> Self {
         Self {
             timeout: Duration::from_secs(5),
@@ -22,6 +25,7 @@ impl Default for DefaultConfigValues {
             compression: None,
             check_compatibility: true,
             pool_size: 3,
+            interceptor: WrappedInterceptor::<I>::default(),
         }
     }
 }
@@ -65,11 +69,11 @@ pub struct QdrantConfig<I: Send + Sync + 'static + Clone + Interceptor = TokenIn
     pub pool_size: usize,
 
     /// The interceptor to use for modifying requests
-    pub interceptor: I,
+    pub interceptor: WrappedInterceptor<I>,
 }
 
 impl<I: Send + Sync + 'static + Clone + Interceptor> QdrantConfig<I> {
-    fn with_defaults(url: &str, interceptor: I) -> Self {
+    fn with_defaults(url: &str) -> Self {
         let defaults = DefaultConfigValues::default();
         Self {
             uri: url.to_string(),
@@ -79,12 +83,20 @@ impl<I: Send + Sync + 'static + Clone + Interceptor> QdrantConfig<I> {
             compression: defaults.compression,
             check_compatibility: defaults.check_compatibility,
             pool_size: defaults.pool_size,
-            interceptor,
+            interceptor: defaults.interceptor,
         }
     }
 
-    pub fn from_url_with_interceptor(url: &str, interceptor: I) -> Self {
-        Self::with_defaults(url, interceptor)
+    /// Start configuring a Qdrant client with an URL
+    ///
+    /// ```rust,no_run
+    ///# use qdrant_client::config::QdrantConfig;
+    /// let client = QdrantConfig::from_url("http://localhost:6334").build();
+    /// ```
+    ///
+    /// This is normally done through [`Qdrant::from_url`](crate::Qdrant::from_url).
+    pub fn from_url(url: &str) -> Self {
+        Self::with_defaults(url)
     }
 
     /// Keep the connection alive while idle
@@ -136,6 +148,33 @@ impl<I: Send + Sync + 'static + Clone + Interceptor> QdrantConfig<I> {
         self
     }
 
+    /// Set the interceptor to use for this client
+    ///
+    /// ```no_run
+    /// use qdrant_client::GenericQdrant;
+    /// use tonic::service::Interceptor;
+    /// use tonic::{Request, Status};
+    ///
+    /// #[derive(Clone)]
+    /// struct CustomInterceptor;
+    /// impl Interceptor for CustomInterceptor {
+    ///     fn call(&mut self, req: Request<()>) -> Result<Request<()>, Status> {
+    ///         Ok(req)
+    ///     }
+    /// }
+    ///
+    ///# async fn connect() -> Result<(), qdrant_client::QdrantError> {
+    /// let client = GenericQdrant<CustomInterceptor>::from_url("http://localhost:6334")
+    /// .interceptor(CustomInterceptor)
+    /// .build()?;
+    ///# Ok(())
+    ///# }
+    /// ```
+    pub fn interceptor(mut self, interceptor: I) -> Self {
+        self.interceptor = WrappedInterceptor::new(interceptor);
+        self
+    }
+
     /// Set the timeout for this client
     ///
     /// Also see [`timeout()`](fn@Self::timeout).
@@ -164,9 +203,16 @@ impl<I: Send + Sync + 'static + Clone + Interceptor> QdrantConfig<I> {
         self.compression = compression;
     }
 
+    /// Set the interceptor to use for this client
+    ///
+    /// Also see [`interceptor()`](fn@Self::interceptor).
+    pub fn set_interceptor(&mut self, interceptor: I) {
+        self.interceptor = WrappedInterceptor::new(interceptor);
+    }
+
     /// Build the configured [`Qdrant`] client
-    pub fn build(self) -> Result<Qdrant<I>, QdrantError> {
-        Qdrant::new(self)
+    pub fn build(self) -> Result<GenericQdrant<I>, QdrantError> {
+        GenericQdrant::new(self)
     }
 
     pub fn skip_compatibility_check(mut self) -> Self {
@@ -182,18 +228,6 @@ impl<I: Send + Sync + 'static + Clone + Interceptor> QdrantConfig<I> {
 }
 
 impl QdrantConfig<TokenInterceptor> {
-    /// Start configuring a Qdrant client with an URL
-    ///
-    /// ```rust,no_run
-    ///# use qdrant_client::config::QdrantConfig;
-    /// let client = QdrantConfig::from_url("http://localhost:6334").build();
-    /// ```
-    ///
-    /// This is normally done through [`Qdrant::from_url`](crate::Qdrant::from_url).
-    pub fn from_url(url: &str) -> Self {
-        Self::with_defaults(url, TokenInterceptor::new(None))
-    }
-
     /// Set an optional API key
     ///
     /// This method is only available when using the default TokenInterceptor.
@@ -209,7 +243,7 @@ impl QdrantConfig<TokenInterceptor> {
     ///     .build();
     /// ```
     pub fn api_key(mut self, api_key: impl AsOptionApiKey) -> Self {
-        self.interceptor = TokenInterceptor::new(api_key.api_key());
+        self.interceptor = WrappedInterceptor::new(TokenInterceptor::new(api_key.api_key()));
         self
     }
 
@@ -217,7 +251,8 @@ impl QdrantConfig<TokenInterceptor> {
     ///
     /// Also see [`api_key()`](fn@Self::api_key).
     pub fn set_api_key(&mut self, api_key: &str) {
-        self.interceptor = TokenInterceptor::new(Some(api_key.to_string()));
+        self.interceptor =
+            WrappedInterceptor::new(TokenInterceptor::new(Some(api_key.to_string())));
     }
 }
 
@@ -226,7 +261,7 @@ impl QdrantConfig<TokenInterceptor> {
 /// Connects to `http://localhost:6334` without an API key.
 impl Default for QdrantConfig<TokenInterceptor> {
     fn default() -> Self {
-        Self::with_defaults("http://localhost:6334", TokenInterceptor::new(None))
+        Self::with_defaults("http://localhost:6334")
     }
 }
 

--- a/src/qdrant_client/index.rs
+++ b/src/qdrant_client/index.rs
@@ -3,14 +3,14 @@ use tonic::service::Interceptor;
 use crate::qdrant::{
     CreateFieldIndexCollection, DeleteFieldIndexCollection, PointsOperationResponse,
 };
-use crate::qdrant_client::{Qdrant, QdrantResult};
+use crate::qdrant_client::{GenericQdrant, QdrantResult};
 
 /// # Index operations
 ///
 /// Manage field and payload indices in collections.
 ///
 /// Documentation: <https://qdrant.tech/documentation/concepts/indexing/>
-impl<I: Send + Sync + 'static + Clone + Interceptor> Qdrant<I> {
+impl<I: Send + Sync + 'static + Clone + Interceptor> GenericQdrant<I> {
     /// Create payload index in a collection.
     ///
     /// ```no_run

--- a/src/qdrant_client/index.rs
+++ b/src/qdrant_client/index.rs
@@ -1,3 +1,5 @@
+use tonic::service::Interceptor;
+
 use crate::qdrant::{
     CreateFieldIndexCollection, DeleteFieldIndexCollection, PointsOperationResponse,
 };
@@ -8,7 +10,7 @@ use crate::qdrant_client::{Qdrant, QdrantResult};
 /// Manage field and payload indices in collections.
 ///
 /// Documentation: <https://qdrant.tech/documentation/concepts/indexing/>
-impl Qdrant {
+impl<I: Send + Sync + 'static + Clone + Interceptor> Qdrant<I> {
     /// Create payload index in a collection.
     ///
     /// ```no_run

--- a/src/qdrant_client/mod.rs
+++ b/src/qdrant_client/mod.rs
@@ -23,6 +23,7 @@ use tonic::Status;
 
 use crate::auth::{TokenInterceptor, WrappedInterceptor};
 use crate::channel_pool::ChannelPool;
+use crate::config::GenericQdrantConfig;
 use crate::qdrant::{qdrant_client, HealthCheckReply, HealthCheckRequest};
 use crate::qdrant_client::config::QdrantConfig;
 use crate::qdrant_client::version_check::is_compatible;
@@ -87,7 +88,7 @@ pub type Qdrant = GenericQdrant<TokenInterceptor>;
 #[derive(Clone)]
 pub struct GenericQdrant<I: Send + Sync + 'static + Clone + Interceptor> {
     /// Client configuration
-    pub config: QdrantConfig<I>,
+    pub config: GenericQdrantConfig<I>,
 
     /// Internal connection pool
     channel: Arc<ChannelPool>,
@@ -99,8 +100,8 @@ pub struct GenericQdrant<I: Send + Sync + 'static + Clone + Interceptor> {
 impl<I: Send + Sync + 'static + Clone + Interceptor> GenericQdrant<I> {
     /// Create a new Qdrant client.
     ///
-    /// Constructs the client and connects based on the given [`QdrantConfig`](config::QdrantConfig).
-    pub fn new(config: QdrantConfig<I>) -> QdrantResult<Self> {
+    /// Constructs the client and connects based on the given [`GenericQdrantConfig`](config::GenericQdrantConfig).
+    pub fn new(config: GenericQdrantConfig<I>) -> QdrantResult<Self> {
         if config.check_compatibility {
             // create a temporary client to check compatibility
             let channel = ChannelPool::new(
@@ -176,8 +177,8 @@ impl<I: Send + Sync + 'static + Clone + Interceptor> GenericQdrant<I> {
     /// ```
     ///
     /// See more ways to set up the client [here](Self#set-up).
-    pub fn from_url(url: &str) -> QdrantConfig<I> {
-        QdrantConfig::<I>::from_url(url)
+    pub fn from_url(url: &str) -> GenericQdrantConfig<I> {
+        GenericQdrantConfig::<I>::from_url(url)
     }
 
     /// Wraps a channel with the configured interceptor

--- a/src/qdrant_client/payload.rs
+++ b/src/qdrant_client/payload.rs
@@ -3,14 +3,14 @@ use tonic::service::Interceptor;
 use crate::qdrant::{
     ClearPayloadPoints, DeletePayloadPoints, PointsOperationResponse, SetPayloadPoints,
 };
-use crate::qdrant_client::{Qdrant, QdrantResult};
+use crate::qdrant_client::{GenericQdrant, QdrantResult};
 
 /// # Payload operations
 ///
 /// Manage point payloads.
 ///
 /// Documentation: <https://qdrant.tech/documentation/concepts/payload/>
-impl<I: Send + Sync + 'static + Clone + Interceptor> Qdrant<I> {
+impl<I: Send + Sync + 'static + Clone + Interceptor> GenericQdrant<I> {
     /// Set payload of points.
     ///
     /// Sets only the given payload values on a point, leaving other existing payloads in place.

--- a/src/qdrant_client/payload.rs
+++ b/src/qdrant_client/payload.rs
@@ -1,3 +1,5 @@
+use tonic::service::Interceptor;
+
 use crate::qdrant::{
     ClearPayloadPoints, DeletePayloadPoints, PointsOperationResponse, SetPayloadPoints,
 };
@@ -8,7 +10,7 @@ use crate::qdrant_client::{Qdrant, QdrantResult};
 /// Manage point payloads.
 ///
 /// Documentation: <https://qdrant.tech/documentation/concepts/payload/>
-impl Qdrant {
+impl<I: Send + Sync + 'static + Clone + Interceptor> Qdrant<I> {
     /// Set payload of points.
     ///
     /// Sets only the given payload values on a point, leaving other existing payloads in place.

--- a/src/qdrant_client/points.rs
+++ b/src/qdrant_client/points.rs
@@ -5,6 +5,7 @@ use tonic::service::Interceptor;
 use tonic::transport::Channel;
 use tonic::Status;
 
+use crate::auth::WrappedInterceptor;
 use crate::qdrant::points_client::PointsClient;
 use crate::qdrant::{
     CountPoints, CountResponse, DeletePointVectors, DeletePoints, FacetCounts, FacetResponse,
@@ -12,17 +13,17 @@ use crate::qdrant::{
     SearchMatrixOffsetsResponse, SearchMatrixPairsResponse, SearchMatrixPoints, UpdateBatchPoints,
     UpdateBatchResponse, UpdatePointVectors, UpsertPoints, Usage,
 };
-use crate::qdrant_client::{Qdrant, QdrantResult};
+use crate::qdrant_client::{GenericQdrant, QdrantResult};
 
 /// # Point operations
 ///
 /// Manage points and vectors.
 ///
 /// Documentation: <https://qdrant.tech/documentation/concepts/points/>
-impl<I: Send + Sync + 'static + Clone + Interceptor> Qdrant<I> {
+impl<I: Send + Sync + 'static + Clone + Interceptor> GenericQdrant<I> {
     pub(crate) async fn with_points_client<T, O: Future<Output = Result<T, Status>>>(
         &self,
-        f: impl Fn(PointsClient<InterceptedService<Channel, I>>) -> O,
+        f: impl Fn(PointsClient<InterceptedService<Channel, WrappedInterceptor<I>>>) -> O,
     ) -> QdrantResult<T> {
         let result = self
             .channel

--- a/src/qdrant_client/points.rs
+++ b/src/qdrant_client/points.rs
@@ -1,10 +1,10 @@
 use std::future::Future;
 
 use tonic::codegen::InterceptedService;
+use tonic::service::Interceptor;
 use tonic::transport::Channel;
 use tonic::Status;
 
-use crate::auth::TokenInterceptor;
 use crate::qdrant::points_client::PointsClient;
 use crate::qdrant::{
     CountPoints, CountResponse, DeletePointVectors, DeletePoints, FacetCounts, FacetResponse,
@@ -19,16 +19,16 @@ use crate::qdrant_client::{Qdrant, QdrantResult};
 /// Manage points and vectors.
 ///
 /// Documentation: <https://qdrant.tech/documentation/concepts/points/>
-impl Qdrant {
+impl<I: Send + Sync + 'static + Clone + Interceptor> Qdrant<I> {
     pub(crate) async fn with_points_client<T, O: Future<Output = Result<T, Status>>>(
         &self,
-        f: impl Fn(PointsClient<InterceptedService<Channel, TokenInterceptor>>) -> O,
+        f: impl Fn(PointsClient<InterceptedService<Channel, I>>) -> O,
     ) -> QdrantResult<T> {
         let result = self
             .channel
             .with_channel(
                 |channel| {
-                    let service = self.with_api_key(channel);
+                    let service = self.with_interceptor(channel);
                     let mut client =
                         PointsClient::new(service).max_decoding_message_size(usize::MAX);
                     if let Some(compression) = self.config.compression {

--- a/src/qdrant_client/query.rs
+++ b/src/qdrant_client/query.rs
@@ -5,14 +5,14 @@ use crate::qdrant::{
     QueryBatchPoints, QueryBatchResponse, QueryGroupsResponse, QueryPointGroups, QueryPoints,
     QueryResponse,
 };
-use crate::qdrant_client::Qdrant;
+use crate::qdrant_client::GenericQdrant;
 
 /// # Query operations
 ///
 /// Query points using the universal search API.
 ///
 /// Documentation: <https://qdrant.tech/documentation/concepts/search/#query-api>
-impl<I: Send + Sync + 'static + Clone + Interceptor> Qdrant<I> {
+impl<I: Send + Sync + 'static + Clone + Interceptor> GenericQdrant<I> {
     /// Query points in a collection.
     ///
     /// ```no_run
@@ -134,7 +134,6 @@ impl<I: Send + Sync + 'static + Clone + Interceptor> Qdrant<I> {
 mod tests {
     use serde_json::json;
 
-    use super::*;
     use crate::builders::CreateCollectionBuilder;
     use crate::qdrant::{
         ContextInputBuilder, CreateFieldIndexCollectionBuilder, Datatype, DiscoverInputBuilder,
@@ -144,7 +143,7 @@ mod tests {
         SparseVectorParamsBuilder, SparseVectorsConfigBuilder, UpsertPointsBuilder, Vector,
         VectorInput, VectorParamsBuilder, VectorsConfigBuilder,
     };
-    use crate::Payload;
+    use crate::{Payload, Qdrant};
 
     #[tokio::test]
     async fn test_query() {

--- a/src/qdrant_client/query.rs
+++ b/src/qdrant_client/query.rs
@@ -1,3 +1,5 @@
+use tonic::service::Interceptor;
+
 use super::QdrantResult;
 use crate::qdrant::{
     QueryBatchPoints, QueryBatchResponse, QueryGroupsResponse, QueryPointGroups, QueryPoints,
@@ -10,7 +12,7 @@ use crate::qdrant_client::Qdrant;
 /// Query points using the universal search API.
 ///
 /// Documentation: <https://qdrant.tech/documentation/concepts/search/#query-api>
-impl Qdrant {
+impl<I: Send + Sync + 'static + Clone + Interceptor> Qdrant<I> {
     /// Query points in a collection.
     ///
     /// ```no_run

--- a/src/qdrant_client/search.rs
+++ b/src/qdrant_client/search.rs
@@ -1,3 +1,5 @@
+use tonic::service::Interceptor;
+
 use crate::qdrant::{
     DiscoverBatchPoints, DiscoverBatchResponse, DiscoverPoints, DiscoverResponse,
     RecommendBatchPoints, RecommendBatchResponse, RecommendGroupsResponse, RecommendPointGroups,
@@ -15,7 +17,7 @@ use crate::qdrant_client::{Qdrant, QdrantResult};
 /// Search and explore points.
 ///
 /// Documentation: <https://qdrant.tech/documentation/concepts/search/>
-impl Qdrant {
+impl<I: Send + Sync + 'static + Clone + Interceptor> Qdrant<I> {
     /// Search points in a collection.
     ///
     /// ```no_run

--- a/src/qdrant_client/search.rs
+++ b/src/qdrant_client/search.rs
@@ -6,7 +6,7 @@ use crate::qdrant::{
     RecommendPoints, RecommendResponse, SearchBatchPoints, SearchBatchResponse,
     SearchGroupsResponse, SearchPointGroups, SearchPoints, SearchResponse,
 };
-use crate::qdrant_client::{Qdrant, QdrantResult};
+use crate::qdrant_client::{GenericQdrant, QdrantResult};
 
 /// # Search operations
 ///
@@ -17,7 +17,7 @@ use crate::qdrant_client::{Qdrant, QdrantResult};
 /// Search and explore points.
 ///
 /// Documentation: <https://qdrant.tech/documentation/concepts/search/>
-impl<I: Send + Sync + 'static + Clone + Interceptor> Qdrant<I> {
+impl<I: Send + Sync + 'static + Clone + Interceptor> GenericQdrant<I> {
     /// Search points in a collection.
     ///
     /// ```no_run

--- a/src/qdrant_client/sharding_keys.rs
+++ b/src/qdrant_client/sharding_keys.rs
@@ -1,3 +1,5 @@
+use tonic::service::Interceptor;
+
 use crate::qdrant::{
     CreateShardKeyRequest, CreateShardKeyResponse, DeleteShardKeyRequest, DeleteShardKeyResponse,
     ListShardKeysRequest, ListShardKeysResponse,
@@ -9,7 +11,7 @@ use crate::qdrant_client::{Qdrant, QdrantResult};
 /// Create or delete shard keys for collections.
 ///
 /// Documentation: <https://qdrant.tech/documentation/guides/distributed_deployment/#user-defined-sharding>
-impl Qdrant {
+impl<I: Send + Sync + 'static + Clone + Interceptor> Qdrant<I> {
     /// Create new shard key in a collection.
     ///
     /// ```no_run

--- a/src/qdrant_client/sharding_keys.rs
+++ b/src/qdrant_client/sharding_keys.rs
@@ -4,14 +4,14 @@ use crate::qdrant::{
     CreateShardKeyRequest, CreateShardKeyResponse, DeleteShardKeyRequest, DeleteShardKeyResponse,
     ListShardKeysRequest, ListShardKeysResponse,
 };
-use crate::qdrant_client::{Qdrant, QdrantResult};
+use crate::qdrant_client::{GenericQdrant, QdrantResult};
 
 /// # Sharding key operations
 ///
 /// Create or delete shard keys for collections.
 ///
 /// Documentation: <https://qdrant.tech/documentation/guides/distributed_deployment/#user-defined-sharding>
-impl<I: Send + Sync + 'static + Clone + Interceptor> Qdrant<I> {
+impl<I: Send + Sync + 'static + Clone + Interceptor> GenericQdrant<I> {
     /// Create new shard key in a collection.
     ///
     /// ```no_run

--- a/src/qdrant_client/snapshot.rs
+++ b/src/qdrant_client/snapshot.rs
@@ -5,23 +5,24 @@ use tonic::service::Interceptor;
 use tonic::transport::Channel;
 use tonic::Status;
 
+use crate::auth::WrappedInterceptor;
 use crate::qdrant::snapshots_client::SnapshotsClient;
 use crate::qdrant::{
     CreateFullSnapshotRequest, CreateSnapshotRequest, CreateSnapshotResponse,
     DeleteFullSnapshotRequest, DeleteSnapshotRequest, DeleteSnapshotResponse,
     ListFullSnapshotsRequest, ListSnapshotsRequest, ListSnapshotsResponse,
 };
-use crate::qdrant_client::{Qdrant, QdrantResult};
+use crate::qdrant_client::{GenericQdrant, QdrantResult};
 
 /// # Snapshot operations
 ///
 /// Create, recover and manage snapshots for collections or a full Qdrant instance.
 ///
 /// Documentation: <https://qdrant.tech/documentation/concepts/snapshots/>
-impl<I: Send + Sync + 'static + Clone + Interceptor> Qdrant<I> {
+impl<I: Send + Sync + 'static + Clone + Interceptor> GenericQdrant<I> {
     async fn with_snapshot_client<T, O: Future<Output = Result<T, Status>>>(
         &self,
-        f: impl Fn(SnapshotsClient<InterceptedService<Channel, I>>) -> O,
+        f: impl Fn(SnapshotsClient<InterceptedService<Channel, WrappedInterceptor<I>>>) -> O,
     ) -> QdrantResult<T> {
         let result = self
             .channel


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Description

This PR adds support for user-defined interceptors in the Qdrant client like in other Qdrant clients

### Key Changes

1. **New `WrappedInterceptor` struct**: A generic wrapper that holds an optional interceptor, allowing for seamless handling of cases where no interceptor is configured.

2. **Generic `QdrantConfig<I>`**: The configuration struct is now generic over the interceptor type `I`, with `TokenInterceptor` as the default.

3. **Generic `GenericQdrant<I>`**: The main client was renamed to GenericQdrant. Added the alias `pub type Qdrant = GenericQdrant<TokenInterceptor> to avoid breaking backward compatibility. GenericQdrant struct is also generic over the interceptor type, enabling users to plug in custom interceptors.

4. Moved `api_key` and `set_api_key` methods to `QdrantConfig<TokenInterceptor>` specialization, also removed `api_key` field from QdrantConfig, it was placed into `TokenInterceptor`.

### Example Usage

```rust
#[derive(Clone)]
struct LoggingInterceptor;
impl Interceptor for LoggingInterceptor {
    fn call(&mut self, req: Request<()>) -> Result<Request<()>, Status> {
        println!("Request: {:?}", req);
        Ok(req)
    }
}

let client = GenericQdrant::<LoggingInterceptor>::from_url("http://localhost:6334")
    .interceptor(LoggingInterceptor)
    .build()?;

// Or stick with the default TokenInterceptor
let client = Qdrant::from_url("http://localhost:6334")
    .api_key("secret")
    .build()?;