### PR TITLE
feat: add custom TLS config support

### DIFF
--- a/src/channel_pool.rs
+++ b/src/channel_pool.rs
@@ -16,6 +16,7 @@ pub struct ChannelPool {
     connection_timeout: Duration,
     keep_alive_while_idle: bool,
     pool_size: usize,
+    tls_config: Option<ClientTlsConfig>,
 }
 
 impl ChannelPool {
@@ -25,6 +26,7 @@ impl ChannelPool {
         connection_timeout: Duration,
         keep_alive_while_idle: bool,
         mut pool_size: usize,
+        tls_config: Option<ClientTlsConfig>,
     ) -> Self {
         // Ensure `pool_size` is always >= 1
         pool_size = std::cmp::max(pool_size, 1);
@@ -37,6 +39,7 @@ impl ChannelPool {
             connection_timeout,
             keep_alive_while_idle,
             pool_size,
+            tls_config,
         }
     }
 
@@ -66,7 +69,10 @@ impl ChannelPool {
             .expect("Version info should be a valid header value");
 
         let endpoint = if tls {
-            let tls_config = ClientTlsConfig::new().with_native_roots();
+            let tls_config = self
+                .tls_config
+                .clone()
+                .unwrap_or(ClientTlsConfig::new().with_native_roots());
             endpoint
                 .tls_config(tls_config)
                 .map_err(|e| Status::internal(format!("Failed to create TLS config: {e}")))?
@@ -168,6 +174,7 @@ fn require_get_channel_fn_to_be_send() {
             Duration::from_millis(0),
             false,
             2,
+            None,
         )
         .get_channel()
         .await
@@ -187,6 +194,7 @@ mod test {
             Duration::default(),
             false,
             5,
+            None,
         );
 
         assert_eq!(channel.next_channel_index(), 0);

--- a/src/qdrant_client/config.rs
+++ b/src/qdrant_client/config.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use tonic::transport::ClientTlsConfig;
+
 use crate::{Qdrant, QdrantError};
 
 /// Qdrant client configuration
@@ -42,6 +44,9 @@ pub struct QdrantConfig {
     /// Amount of concurrent connections.
     /// If set to 0 or 1, connection pools will be disabled.
     pub pool_size: usize,
+
+    /// Custom configuration for TLS encryption on gRPC channels.
+    pub tls_config: Option<ClientTlsConfig>,
 }
 
 impl QdrantConfig {
@@ -138,6 +143,29 @@ impl QdrantConfig {
         self
     }
 
+    /// Set the TLS configuration to use for this client
+    ///
+    /// ```rust,no_run
+    ///# fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use qdrant_client::Qdrant;
+    /// use tonic::transport::ClientTlsConfig;
+    /// use tonic::transport::Certificate;
+    ///
+    /// let ca_cert_pem = std::fs::read_to_string("path/to/ca.crt")?;
+    /// let tls_config = ClientTlsConfig::new()
+    ///     .ca_certificate(Certificate::from_pem(ca_cert_pem));
+    ///
+    /// let client = Qdrant::from_url("http://localhost:6334")
+    ///     .tls_config(Some(tls_config))
+    ///     .build();
+    ///# Ok(())
+    ///# }
+    /// ```
+    pub fn tls_config(mut self, tls_config: Option<ClientTlsConfig>) -> Self {
+        self.tls_config = tls_config;
+        self
+    }
+
     /// Set an API key
     ///
     /// Also see [`api_key()`](fn@Self::api_key).
@@ -188,6 +216,13 @@ impl QdrantConfig {
     pub fn set_pool_size(&mut self, pool_size: usize) {
         self.pool_size = pool_size;
     }
+
+    /// Set the TLS configuration
+    ///
+    /// Also see [`tls_config()`](fn@Self::tls_config).
+    pub fn set_tls_config(&mut self, tls_config: Option<ClientTlsConfig>) {
+        self.tls_config = tls_config;
+    }
 }
 
 /// Default Qdrant client configuration.
@@ -204,6 +239,7 @@ impl Default for QdrantConfig {
             compression: None,
             check_compatibility: true,
             pool_size: 3,
+            tls_config: None,
         }
     }
 }

--- a/src/qdrant_client/mod.rs
+++ b/src/qdrant_client/mod.rs
@@ -107,6 +107,7 @@ impl Qdrant {
                 config.connect_timeout,
                 config.keep_alive_while_idle,
                 1, // No need to create a pool for the compatibility check.
+                config.tls_config.clone(),
             );
             let client = Self {
                 channel: Arc::new(channel),
@@ -152,6 +153,7 @@ impl Qdrant {
             config.connect_timeout,
             config.keep_alive_while_idle,
             config.pool_size,
+            config.tls_config.clone(),
         );
 
         let client = Self {


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --all --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Description

This PR adds support for custom TLS configuration in Qdrant client. This enhancement allows users to provide their own `ClientTlsConfig`, offering greater flexibility for connecting to Qdrant in various environments

### Changes:

1. Added a `tls_config: Option<ClientTlsConfig>` field to the `QdrantConfig` struct.
2. Added a `tls_config: Option<ClientTlsConfig>` field to the `ChannelPool` struct.
3. Introduced `tls_config` and `set_tls_config` methods to `QdrantConfig` for configuring TLS.
4. Updated `make_channel` method within `ChannelPool` to use the custom `tls_config` if provided, falling back to the default `ClientTlsConfig::new().with_native_roots()` otherwise.

### Example Usage

```rust
let ca_cert_pem = std::fs::read_to_string("path/to/ca.crt")?;
let tls_config = ClientTlsConfig::new()
    .ca_certificate(Certificate::from_pem(ca_cert_pem));

let client = Qdrant::from_url("http://localhost:6334")
    .tls_config(Some(custom_tls_config))
    .build()?;