### PR TITLE
Enforce must_use on builder types

### DIFF
--- a/src/builders/abort_shard_transfer_builder.rs
+++ b/src/builders/abort_shard_transfer_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct AbortShardTransferBuilder {
     /// Local shard id

--- a/src/builders/acorn_search_params_builder.rs
+++ b/src/builders/acorn_search_params_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::AcornSearchParams;
 
+#[must_use]
 #[derive(Clone)]
 pub struct AcornSearchParamsBuilder {
     /// If true, then ACORN may be used for the HNSW search based on filters selectivity.

--- a/src/builders/binary_quantization_builder.rs
+++ b/src/builders/binary_quantization_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct BinaryQuantizationBuilder {
     /// If true - quantized vectors always will be stored in RAM, ignoring the config of main storage

--- a/src/builders/bool_index_params_builder.rs
+++ b/src/builders/bool_index_params_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct BoolIndexParamsBuilder {
     /// If true - store index on disk.

--- a/src/builders/clear_payload_points_builder.rs
+++ b/src/builders/clear_payload_points_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct ClearPayloadPointsBuilder {
     /// name of the collection

--- a/src/builders/collection_params_diff_builder.rs
+++ b/src/builders/collection_params_diff_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct CollectionParamsDiffBuilder {
     /// Number of replicas of each shard that network tries to maintain

--- a/src/builders/context_example_pair_builder.rs
+++ b/src/builders/context_example_pair_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct ContextExamplePairBuilder {
     pub(crate) positive: Option<Option<VectorExample>>,

--- a/src/builders/context_input_builder.rs
+++ b/src/builders/context_input_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct ContextInputBuilder {
     /// Search space will be constrained by these pairs of vectors

--- a/src/builders/context_input_pair_builder.rs
+++ b/src/builders/context_input_pair_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct ContextInputPairBuilder {
     /// A positive vector

--- a/src/builders/count_points_builder.rs
+++ b/src/builders/count_points_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct CountPointsBuilder {
     /// Name of the collection

--- a/src/builders/create_alias_builder.rs
+++ b/src/builders/create_alias_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct CreateAliasBuilder {
     /// Name of the collection

--- a/src/builders/create_collection_builder.rs
+++ b/src/builders/create_collection_builder.rs
@@ -4,6 +4,7 @@ use crate::grpc_conversions::metadata::MetadataWrapper;
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Debug, Clone)]
 pub struct CreateCollectionBuilder {
     /// Name of the collection

--- a/src/builders/create_field_index_collection_builder.rs
+++ b/src/builders/create_field_index_collection_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct CreateFieldIndexCollectionBuilder {
     /// name of the collection

--- a/src/builders/create_shard_key_builder.rs
+++ b/src/builders/create_shard_key_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct CreateShardKeyBuilder {
     /// User-defined shard key

--- a/src/builders/create_shard_key_request_builder.rs
+++ b/src/builders/create_shard_key_request_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct CreateShardKeyRequestBuilder {
     /// Name of the collection

--- a/src/builders/datetime_index_params_builder.rs
+++ b/src/builders/datetime_index_params_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct DatetimeIndexParamsBuilder {
     /// If true - store index on disk.

--- a/src/builders/decay_params_expression_builder.rs
+++ b/src/builders/decay_params_expression_builder.rs
@@ -4,6 +4,7 @@ use crate::qdrant::*;
 ///
 /// Decay functions (exponential, Gaussian, linear) are used in scoring to create a decay effect
 /// based on distance from a target value.
+#[must_use]
 #[derive(Clone)]
 pub struct DecayParamsExpressionBuilder {
     /// The variable to decay

--- a/src/builders/delete_collection_builder.rs
+++ b/src/builders/delete_collection_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct DeleteCollectionBuilder {
     /// Name of the collection

--- a/src/builders/delete_field_index_collection_builder.rs
+++ b/src/builders/delete_field_index_collection_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct DeleteFieldIndexCollectionBuilder {
     /// name of the collection

--- a/src/builders/delete_payload_points_builder.rs
+++ b/src/builders/delete_payload_points_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct DeletePayloadPointsBuilder {
     /// name of the collection

--- a/src/builders/delete_point_vectors_builder.rs
+++ b/src/builders/delete_point_vectors_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct DeletePointVectorsBuilder {
     /// name of the collection

--- a/src/builders/delete_points_builder.rs
+++ b/src/builders/delete_points_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct DeletePointsBuilder {
     /// name of the collection

--- a/src/builders/delete_shard_key_request_builder.rs
+++ b/src/builders/delete_shard_key_request_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct DeleteShardKeyRequestBuilder {
     /// Name of the collection

--- a/src/builders/delete_snapshot_request_builder.rs
+++ b/src/builders/delete_snapshot_request_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct DeleteSnapshotRequestBuilder {
     /// Name of the collection

--- a/src/builders/dense_vector_builder.rs
+++ b/src/builders/dense_vector_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct DenseVectorBuilder {
     pub(crate) values: Vec<f32>,

--- a/src/builders/discover_batch_points_builder.rs
+++ b/src/builders/discover_batch_points_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct DiscoverBatchPointsBuilder {
     /// Name of the collection

--- a/src/builders/discover_input_builder.rs
+++ b/src/builders/discover_input_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct DiscoverInputBuilder {
     /// Use this as the primary search objective

--- a/src/builders/discover_points_builder.rs
+++ b/src/builders/discover_points_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct DiscoverPointsBuilder {
     /// name of the collection

--- a/src/builders/facet_counts_builder.rs
+++ b/src/builders/facet_counts_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct FacetCountsBuilder {
     /// Name of the collection

--- a/src/builders/feedback_item_builder.rs
+++ b/src/builders/feedback_item_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct FeedbackItemBuilder {
     /// The id or vector from the original model

--- a/src/builders/feedback_strategy_builder.rs
+++ b/src/builders/feedback_strategy_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct FeedbackStrategyBuilder {
     pub(crate) variant: feedback_strategy::Variant,

--- a/src/builders/float_index_params_builder.rs
+++ b/src/builders/float_index_params_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct FloatIndexParamsBuilder {
     /// If true - store index on disk.

--- a/src/builders/formula_builder.rs
+++ b/src/builders/formula_builder.rs
@@ -5,6 +5,7 @@ use crate::qdrant::*;
 /// Builder for the Formula struct, which represents a scoring formula for points.
 ///
 /// The Formula struct is used to define custom scoring expressions and default values.
+#[must_use]
 #[derive(Clone)]
 pub struct FormulaBuilder {
     /// The expression that defines how to score points.

--- a/src/builders/geo_index_params_builder.rs
+++ b/src/builders/geo_index_params_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct GeoIndexParamsBuilder {
     /// If true - store index on disk.

--- a/src/builders/get_points_builder.rs
+++ b/src/builders/get_points_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct GetPointsBuilder {
     /// name of the collection

--- a/src/builders/hnsw_config_diff_builder.rs
+++ b/src/builders/hnsw_config_diff_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct HnswConfigDiffBuilder {
     ///

--- a/src/builders/integer_index_params_builder.rs
+++ b/src/builders/integer_index_params_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct IntegerIndexParamsBuilder {
     /// If true - support direct lookups.

--- a/src/builders/keyword_index_params_builder.rs
+++ b/src/builders/keyword_index_params_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct KeywordIndexParamsBuilder {
     /// If true - used for tenant optimization.

--- a/src/builders/lookup_location_builder.rs
+++ b/src/builders/lookup_location_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct LookupLocationBuilder {
     pub(crate) collection_name: Option<String>,

--- a/src/builders/max_optimization_threads_builder.rs
+++ b/src/builders/max_optimization_threads_builder.rs
@@ -5,6 +5,7 @@ use crate::qdrant::*;
 ///
 /// - If `auto` - have no limit and choose dynamically to saturate CPU.
 /// - If `disabled` or `0` - no optimization threads, optimizations will be disabled.
+#[must_use]
 #[derive(Clone)]
 pub struct MaxOptimizationThreadsBuilder {
     pub(crate) inner: MaxOptimizationThreads,

--- a/src/builders/mmr_builder.rs
+++ b/src/builders/mmr_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::Mmr;
 
+#[must_use]
 #[derive(Clone)]
 pub struct MmrBuilder {
     /// Tunable parameter for the MMR algorithm.

--- a/src/builders/move_shard_builder.rs
+++ b/src/builders/move_shard_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct MoveShardBuilder {
     /// Local shard id

--- a/src/builders/multi_dense_vector_builder.rs
+++ b/src/builders/multi_dense_vector_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone, Default)]
 pub struct MultiDenseVectorBuilder {
     pub(crate) vectors: Vec<DenseVector>,

--- a/src/builders/multi_vector_config_builder.rs
+++ b/src/builders/multi_vector_config_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct MultiVectorConfigBuilder {
     /// Comparator for multi-vector search

--- a/src/builders/optimizers_config_diff_builder.rs
+++ b/src/builders/optimizers_config_diff_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct OptimizersConfigDiffBuilder {
     ///

--- a/src/builders/order_by_builder.rs
+++ b/src/builders/order_by_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct OrderByBuilder {
     /// Payload key to order by

--- a/src/builders/prefetch_query_builder.rs
+++ b/src/builders/prefetch_query_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct PrefetchQueryBuilder {
     /// Sub-requests to perform first. If present, the query will be performed on the results of the prefetches.

--- a/src/builders/product_quantization_builder.rs
+++ b/src/builders/product_quantization_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct ProductQuantizationBuilder {
     /// Compression ratio

--- a/src/builders/quantization_search_params_builder.rs
+++ b/src/builders/quantization_search_params_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct QuantizationSearchParamsBuilder {
     ///

--- a/src/builders/query_batch_points_builder.rs
+++ b/src/builders/query_batch_points_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct QueryBatchPointsBuilder {
     pub(crate) collection_name: Option<String>,

--- a/src/builders/query_point_groups_builder.rs
+++ b/src/builders/query_point_groups_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct QueryPointGroupsBuilder {
     /// Name of the collection

--- a/src/builders/query_points_builder.rs
+++ b/src/builders/query_points_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct QueryPointsBuilder {
     /// Name of the collection

--- a/src/builders/recommend_batch_points_builder.rs
+++ b/src/builders/recommend_batch_points_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct RecommendBatchPointsBuilder {
     /// Name of the collection

--- a/src/builders/recommend_input_builder.rs
+++ b/src/builders/recommend_input_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct RecommendInputBuilder {
     /// Look for vectors closest to the vectors from these points

--- a/src/builders/recommend_point_groups_builder.rs
+++ b/src/builders/recommend_point_groups_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct RecommendPointGroupsBuilder {
     /// Name of the collection

--- a/src/builders/recommend_points_builder.rs
+++ b/src/builders/recommend_points_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct RecommendPointsBuilder {
     /// name of the collection

--- a/src/builders/relevance_feedback_input_builder.rs
+++ b/src/builders/relevance_feedback_input_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct RelevanceFeedbackInputBuilder {
     /// The original query vector

--- a/src/builders/rename_alias_builder.rs
+++ b/src/builders/rename_alias_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct RenameAliasBuilder {
     /// Name of the alias to rename

--- a/src/builders/replica_builder.rs
+++ b/src/builders/replica_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct ReplicaBuilder {
     pub(crate) shard_id: Option<u32>,

--- a/src/builders/replicate_points_builder.rs
+++ b/src/builders/replicate_points_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::{Filter, ReplicatePoints, ShardKey};
 
+#[must_use]
 #[derive(Clone)]
 pub struct ReplicatePointsBuilder {
     /// Source shard key

--- a/src/builders/replicate_shard_builder.rs
+++ b/src/builders/replicate_shard_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct ReplicateShardBuilder {
     /// Local shard id

--- a/src/builders/rrf_builder.rs
+++ b/src/builders/rrf_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::Rrf;
 
+#[must_use]
 #[derive(Clone)]
 pub struct RrfBuilder {
     /// K parameter for reciprocal rank fusion.

--- a/src/builders/scalar_quantization_builder.rs
+++ b/src/builders/scalar_quantization_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct ScalarQuantizationBuilder {
     /// Type of quantization

--- a/src/builders/scroll_points_builder.rs
+++ b/src/builders/scroll_points_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct ScrollPointsBuilder {
     pub(crate) collection_name: Option<String>,

--- a/src/builders/search_batch_points_builder.rs
+++ b/src/builders/search_batch_points_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct SearchBatchPointsBuilder {
     /// Name of the collection

--- a/src/builders/search_matrix_points_builder.rs
+++ b/src/builders/search_matrix_points_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct SearchMatrixPointsBuilder {
     /// Name of the collection

--- a/src/builders/search_params_builder.rs
+++ b/src/builders/search_params_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct SearchParamsBuilder {
     ///

--- a/src/builders/search_point_groups_builder.rs
+++ b/src/builders/search_point_groups_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct SearchPointGroupsBuilder {
     /// Name of the collection

--- a/src/builders/search_points_builder.rs
+++ b/src/builders/search_points_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct SearchPointsBuilder {
     /// name of the collection

--- a/src/builders/set_payload_points_builder.rs
+++ b/src/builders/set_payload_points_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct SetPayloadPointsBuilder {
     /// name of the collection

--- a/src/builders/shard_key_selector_builder.rs
+++ b/src/builders/shard_key_selector_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::{ShardKey, ShardKeySelector};
 
+#[must_use]
 #[derive(Clone)]
 pub struct ShardKeySelectorBuilder {
     /// List of shard keys which should be used in the request

--- a/src/builders/sparse_index_config_builder.rs
+++ b/src/builders/sparse_index_config_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct SparseIndexConfigBuilder {
     ///

--- a/src/builders/sparse_vector_builder.rs
+++ b/src/builders/sparse_vector_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone, Default)]
 pub struct SparseVectorBuilder {
     pub(crate) indices: Vec<u32>,

--- a/src/builders/sparse_vector_params_builder.rs
+++ b/src/builders/sparse_vector_params_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct SparseVectorParamsBuilder {
     /// Configuration of sparse index

--- a/src/builders/strict_mode_config_builder.rs
+++ b/src/builders/strict_mode_config_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct StrictModeConfigBuilder {
     pub(crate) enabled: Option<Option<bool>>,

--- a/src/builders/strict_mode_multivector_config_builder.rs
+++ b/src/builders/strict_mode_multivector_config_builder.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::qdrant::{StrictModeMultivector, StrictModeMultivectorConfig};
 
 /// Builder for StrictModeMultivectorConfig, which defines multivector configuration for strict mode.
+#[must_use]
 #[derive(Clone)]
 pub struct StrictModeMultivectorConfigBuilder {
     /// The multivector configuration map, where keys are vector names and values are their configurations.

--- a/src/builders/strict_mode_sparse_config_builder.rs
+++ b/src/builders/strict_mode_sparse_config_builder.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::qdrant::{StrictModeSparse, StrictModeSparseConfig};
 
 /// Builder for StrictModeSparseConfig, which defines sparse vector configuration for strict mode.
+#[must_use]
 #[derive(Clone)]
 pub struct StrictModeSparseConfigBuilder {
     /// The sparse vectors configuration map, where keys are vector names and values are their configurations.

--- a/src/builders/text_index_params_builder.rs
+++ b/src/builders/text_index_params_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct TextIndexParamsBuilder {
     /// Tokenizer type

--- a/src/builders/update_batch_points_builder.rs
+++ b/src/builders/update_batch_points_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct UpdateBatchPointsBuilder {
     /// name of the collection

--- a/src/builders/update_collection_builder.rs
+++ b/src/builders/update_collection_builder.rs
@@ -2,6 +2,7 @@ use crate::grpc_conversions::metadata::MetadataWrapper;
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct UpdateCollectionBuilder {
     /// Name of the collection

--- a/src/builders/update_collection_cluster_setup_request_builder.rs
+++ b/src/builders/update_collection_cluster_setup_request_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct UpdateCollectionClusterSetupRequestBuilder {
     /// Name of the collection

--- a/src/builders/update_point_vectors_builder.rs
+++ b/src/builders/update_point_vectors_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct UpdatePointVectorsBuilder {
     /// name of the collection

--- a/src/builders/upsert_points_builder.rs
+++ b/src/builders/upsert_points_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct UpsertPointsBuilder {
     /// name of the collection

--- a/src/builders/uuid_index_params_builder.rs
+++ b/src/builders/uuid_index_params_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct UuidIndexParamsBuilder {
     /// If true - used for tenant optimization.

--- a/src/builders/vector_params_builder.rs
+++ b/src/builders/vector_params_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct VectorParamsBuilder {
     /// Size of the vectors

--- a/src/builders/vector_params_diff_builder.rs
+++ b/src/builders/vector_params_diff_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct VectorParamsDiffBuilder {
     /// Update params for HNSW index. If empty object - it will be unset

--- a/src/builders/wal_config_diff_builder.rs
+++ b/src/builders/wal_config_diff_builder.rs
@@ -1,5 +1,6 @@
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct WalConfigDiffBuilder {
     /// Size of a single WAL block file

--- a/src/builders/with_lookup_builder.rs
+++ b/src/builders/with_lookup_builder.rs
@@ -1,6 +1,7 @@
 use crate::grpc_macros::convert_option;
 use crate::qdrant::*;
 
+#[must_use]
 #[derive(Clone)]
 pub struct WithLookupBuilder {
     /// Name of the collection to use for points lookup


### PR DESCRIPTION
It is easy to misuse a builder without having the help of the compile.

```rust
  let prefetch_query = PrefetchQueryBuilder::default();
  prefetch_query.query(query.clone()); // unused return value of `PrefetchQueryBuilder` that must be used
```