### PR TITLE
Bump version to 1.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant-client"
-version = "1.17.0"
+version = "1.18.0"
 edition = "2021"
 authors = ["Qdrant Team <team@qdrant.com>"]
 description = "Rust client for Qdrant Vector Search Engine"

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -11,7 +11,7 @@ function stop_docker()
 # Ensure current path is project root
 cd "$(dirname "$0")/../"
 
-QDRANT_VERSION='v1.17.0'
+QDRANT_VERSION='v1.18.0'
 
 QDRANT_HOST='localhost:6333'
 


### PR DESCRIPTION
Follows the pattern of <https://github.com/qdrant/rust-client/pull/265>