### PR TITLE
ci: replace arduino/setup-protoc (node20) with apt-get install

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,9 +14,7 @@ jobs:
           components: rustfmt, clippy
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        run: sudo apt-get install -y protobuf-compiler
       - name: Check code formatting
         run: cargo fmt --all -- --check
       - name: Check cargo clippy warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,7 @@ jobs:
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        run: sudo apt-get install -y protobuf-compiler
       - name: Run integration tests
         run: |
           ./tests/integration-tests.sh


### PR DESCRIPTION
## Summary
- `arduino/setup-protoc` v3.0.0 is the latest release and still runs on Node.js 20, with no node24 update (arduino/setup-protoc#112)
- GitHub will force node24 on June 2, 2026
- Replace with `sudo apt-get install -y protobuf-compiler` in lint.yml and test.yml, which has no JS runtime dependency