### PR TITLE
chore: add dependabot cooldown configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
           - "patch"
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -34,3 +36,5 @@ updates:
           - "patch"
         patterns:
           - "*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Add cooldown configuration (default-days: 7) to all dependabot ecosystem blocks to reduce PR noise.