### PR TITLE
Sync 1.19 client with latest dev protobuf

### DIFF
--- a/proto/collections.proto
+++ b/proto/collections.proto
@@ -494,12 +494,12 @@ message StrictModeConfig {
   optional uint64 max_points_count = 18;
   // Max number of payload indexes in a collection
   optional uint64 max_payload_index_count = 19;
+  // Deprecated: memory is node-wide, use the global quota config instead. Removal planned for 1.21.
   // Reject memory-consuming update operations when process resident memory exceeds this percentage of total RAM (cgroup-aware, 1-100).
   // Delete-style operations are still allowed so memory can be freed.
-  optional uint32 max_resident_memory_percent = 21;
-  // Reject disk-consuming update operations when the filesystem hosting Qdrant storage exceeds this percentage of total capacity (1-100).
-  // Free space is sampled with a small TTL cache so the gate may take a few seconds to react. Delete-style operations are still allowed so disk can be freed.
-  optional uint32 max_disk_usage_percent = 22;
+  optional uint32 max_resident_memory_percent = 21 [deprecated = true];
+  // 22 was `max_disk_usage_percent`, superseded by the global quota config
+  reserved 22;
 }
 
 message StrictModeSparseConfig {

--- a/proto/points_service.proto
+++ b/proto/points_service.proto
@@ -37,24 +37,48 @@ service Points {
   rpc DeleteVectorName(DeleteVectorNameRequest) returns (PointsOperationResponse) {}
   // Retrieve closest points based on vector similarity and given filtering
   // conditions
-  rpc Search(SearchPoints) returns (SearchResponse) {}
+  //
+  // Deprecated: use `Query` instead.
+  rpc Search(SearchPoints) returns (SearchResponse) {
+    option deprecated = true;
+  }
   // Retrieve closest points based on vector similarity and given filtering
   // conditions
-  rpc SearchBatch(SearchBatchPoints) returns (SearchBatchResponse) {}
+  //
+  // Deprecated: use `QueryBatch` instead.
+  rpc SearchBatch(SearchBatchPoints) returns (SearchBatchResponse) {
+    option deprecated = true;
+  }
   // Retrieve closest points based on vector similarity and given filtering
   // conditions, grouped by a given field
-  rpc SearchGroups(SearchPointGroups) returns (SearchGroupsResponse) {}
+  //
+  // Deprecated: use `QueryGroups` instead.
+  rpc SearchGroups(SearchPointGroups) returns (SearchGroupsResponse) {
+    option deprecated = true;
+  }
   // Iterate over all or filtered points
   rpc Scroll(ScrollPoints) returns (ScrollResponse) {}
   // Look for the points which are closer to stored positive examples and at
   // the same time further to negative examples.
-  rpc Recommend(RecommendPoints) returns (RecommendResponse) {}
+  //
+  // Deprecated: use `Query` with a `recommend` query instead.
+  rpc Recommend(RecommendPoints) returns (RecommendResponse) {
+    option deprecated = true;
+  }
   // Look for the points which are closer to stored positive examples and at
   // the same time further to negative examples.
-  rpc RecommendBatch(RecommendBatchPoints) returns (RecommendBatchResponse) {}
+  //
+  // Deprecated: use `QueryBatch` with `recommend` queries instead.
+  rpc RecommendBatch(RecommendBatchPoints) returns (RecommendBatchResponse) {
+    option deprecated = true;
+  }
   // Look for the points which are closer to stored positive examples and at
   // the same time further to negative examples, grouped by a given field
-  rpc RecommendGroups(RecommendPointGroups) returns (RecommendGroupsResponse) {}
+  //
+  // Deprecated: use `QueryGroups` with a `recommend` query instead.
+  rpc RecommendGroups(RecommendPointGroups) returns (RecommendGroupsResponse) {
+    option deprecated = true;
+  }
   // Use context and a target to find the most similar points to the target,
   // constrained by the context.
   //
@@ -74,9 +98,17 @@ service Points {
   // distance to the target. The context part of the score for each pair is
   // calculated +1 if the point is closer to a positive than to a negative part
   // of a pair, and -1 otherwise.
-  rpc Discover(DiscoverPoints) returns (DiscoverResponse) {}
+  //
+  // Deprecated: use `Query` with a `discover` or `context` query instead.
+  rpc Discover(DiscoverPoints) returns (DiscoverResponse) {
+    option deprecated = true;
+  }
   // Batch request points based on { positive, negative } pairs of examples, and/or a target
-  rpc DiscoverBatch(DiscoverBatchPoints) returns (DiscoverBatchResponse) {}
+  //
+  // Deprecated: use `QueryBatch` with `discover` or `context` queries instead.
+  rpc DiscoverBatch(DiscoverBatchPoints) returns (DiscoverBatchResponse) {
+    option deprecated = true;
+  }
   // Count points in collection with given filtering conditions
   rpc Count(CountPoints) returns (CountResponse) {}
 

--- a/proto/quota_internal.proto
+++ b/proto/quota_internal.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package qdrant;
+option csharp_namespace = "Qdrant.Client.Grpc";
+
+message GetQuotaUsageRequest {}
+
+message GetQuotaUsageResponse {
+  QuotaUsage result = 1;
+  // Time spent to process
+  double time = 2;
+}
+
+// Utilization of the quota-managed resources on the peer that answered.
+message QuotaUsage {
+  // Resident memory as a percentage of the memory available to the process,
+  // absent when the platform does not expose the stat.
+  optional uint32 resident_memory_percent = 1;
+  // Used space of the storage filesystem as a percentage of its capacity,
+  // absent when it cannot be read.
+  optional uint32 disk_usage_percent = 2;
+  // Whether this peer is at or over one of the limits it enforces, and so is
+  // currently refusing updates. Always false while the quota is disabled.
+  bool exceeded = 3;
+}

--- a/src/builders/strict_mode_config_builder.rs
+++ b/src/builders/strict_mode_config_builder.rs
@@ -23,8 +23,11 @@ pub struct StrictModeConfigBuilder {
     pub(crate) sparse_config: Option<Option<StrictModeSparseConfig>>,
     pub(crate) max_points_count: Option<Option<u64>>,
     pub(crate) max_payload_index_count: Option<Option<u64>>,
+    ///
+    /// Reject memory-consuming update operations when process resident memory exceeds this
+    /// percentage of total RAM (cgroup-aware, 1-100).
+    /// Delete-style operations are still allowed so memory can be freed.
     pub(crate) max_resident_memory_percent: Option<Option<u32>>,
-    pub(crate) max_disk_usage_percent: Option<Option<u32>>,
 }
 
 impl StrictModeConfigBuilder {
@@ -148,20 +151,20 @@ impl StrictModeConfigBuilder {
         new
     }
 
+    ///
+    /// Reject memory-consuming update operations when process resident memory exceeds this
+    /// percentage of total RAM (cgroup-aware, 1-100).
+    /// Delete-style operations are still allowed so memory can be freed.
+    ///
+    /// Deprecated since 1.20.0, memory is node-wide: use the global quota config instead.
+    /// Removal planned for 1.21.
     pub fn max_resident_memory_percent(self, value: u32) -> Self {
         let mut new = self;
         new.max_resident_memory_percent = Option::Some(Option::Some(value));
         new
     }
 
-    /// Reject disk-consuming update operations when the filesystem hosting Qdrant storage
-    /// exceeds this percentage of total capacity (1-100).
-    pub fn max_disk_usage_percent(self, value: u32) -> Self {
-        let mut new = self;
-        new.max_disk_usage_percent = Option::Some(Option::Some(value));
-        new
-    }
-
+    #[allow(deprecated)]
     fn build_inner(self) -> Result<StrictModeConfig, std::convert::Infallible> {
         Ok(StrictModeConfig {
             enabled: self.enabled.unwrap_or_default(),
@@ -189,7 +192,6 @@ impl StrictModeConfigBuilder {
             max_points_count: self.max_points_count.unwrap_or_default(),
             max_payload_index_count: self.max_payload_index_count.unwrap_or_default(),
             max_resident_memory_percent: self.max_resident_memory_percent.unwrap_or_default(),
-            max_disk_usage_percent: self.max_disk_usage_percent.unwrap_or_default(),
         })
     }
     /// Create an empty builder, with all fields set to `None` or `PhantomData`.
@@ -216,7 +218,6 @@ impl StrictModeConfigBuilder {
             max_points_count: core::default::Default::default(),
             max_payload_index_count: core::default::Default::default(),
             max_resident_memory_percent: core::default::Default::default(),
-            max_disk_usage_percent: core::default::Default::default(),
         }
     }
 }

--- a/src/qdrant.rs
+++ b/src/qdrant.rs
@@ -962,14 +962,12 @@ pub struct StrictModeConfig {
     /// Max number of payload indexes in a collection
     #[prost(uint64, optional, tag = "19")]
     pub max_payload_index_count: ::core::option::Option<u64>,
+    /// Deprecated: memory is node-wide, use the global quota config instead. Removal planned for 1.21.
     /// Reject memory-consuming update operations when process resident memory exceeds this percentage of total RAM (cgroup-aware, 1-100).
     /// Delete-style operations are still allowed so memory can be freed.
+    #[deprecated]
     #[prost(uint32, optional, tag = "21")]
     pub max_resident_memory_percent: ::core::option::Option<u32>,
-    /// Reject disk-consuming update operations when the filesystem hosting Qdrant storage exceeds this percentage of total capacity (1-100).
-    /// Free space is sampled with a small TTL cache so the gate may take a few seconds to react. Delete-style operations are still allowed so disk can be freed.
-    #[prost(uint32, optional, tag = "22")]
-    pub max_disk_usage_percent: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StrictModeSparseConfig {
@@ -6732,6 +6730,9 @@ pub mod points_client {
         }
         /// Retrieve closest points based on vector similarity and given filtering
         /// conditions
+        ///
+        /// Deprecated: use `Query` instead.
+        #[deprecated]
         pub async fn search(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchPoints>,
@@ -6752,6 +6753,9 @@ pub mod points_client {
         }
         /// Retrieve closest points based on vector similarity and given filtering
         /// conditions
+        ///
+        /// Deprecated: use `QueryBatch` instead.
+        #[deprecated]
         pub async fn search_batch(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchBatchPoints>,
@@ -6777,6 +6781,9 @@ pub mod points_client {
         }
         /// Retrieve closest points based on vector similarity and given filtering
         /// conditions, grouped by a given field
+        ///
+        /// Deprecated: use `QueryGroups` instead.
+        #[deprecated]
         pub async fn search_groups(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchPointGroups>,
@@ -6822,6 +6829,9 @@ pub mod points_client {
         }
         /// Look for the points which are closer to stored positive examples and at
         /// the same time further to negative examples.
+        ///
+        /// Deprecated: use `Query` with a `recommend` query instead.
+        #[deprecated]
         pub async fn recommend(
             &mut self,
             request: impl tonic::IntoRequest<super::RecommendPoints>,
@@ -6845,6 +6855,9 @@ pub mod points_client {
         }
         /// Look for the points which are closer to stored positive examples and at
         /// the same time further to negative examples.
+        ///
+        /// Deprecated: use `QueryBatch` with `recommend` queries instead.
+        #[deprecated]
         pub async fn recommend_batch(
             &mut self,
             request: impl tonic::IntoRequest<super::RecommendBatchPoints>,
@@ -6871,6 +6884,9 @@ pub mod points_client {
         }
         /// Look for the points which are closer to stored positive examples and at
         /// the same time further to negative examples, grouped by a given field
+        ///
+        /// Deprecated: use `QueryGroups` with a `recommend` query instead.
+        #[deprecated]
         pub async fn recommend_groups(
             &mut self,
             request: impl tonic::IntoRequest<super::RecommendPointGroups>,
@@ -6914,6 +6930,9 @@ pub mod points_client {
         /// distance to the target. The context part of the score for each pair is
         /// calculated +1 if the point is closer to a positive than to a negative part
         /// of a pair, and -1 otherwise.
+        ///
+        /// Deprecated: use `Query` with a `discover` or `context` query instead.
+        #[deprecated]
         pub async fn discover(
             &mut self,
             request: impl tonic::IntoRequest<super::DiscoverPoints>,
@@ -6936,6 +6955,9 @@ pub mod points_client {
             self.inner.unary(req, path, codec).await
         }
         /// Batch request points based on { positive, negative } pairs of examples, and/or a target
+        ///
+        /// Deprecated: use `QueryBatch` with `discover` or `context` queries instead.
+        #[deprecated]
         pub async fn discover_batch(
             &mut self,
             request: impl tonic::IntoRequest<super::DiscoverBatchPoints>,
@@ -7264,12 +7286,16 @@ pub mod points_server {
         >;
         /// Retrieve closest points based on vector similarity and given filtering
         /// conditions
+        ///
+        /// Deprecated: use `Query` instead.
         async fn search(
             &self,
             request: tonic::Request<super::SearchPoints>,
         ) -> std::result::Result<tonic::Response<super::SearchResponse>, tonic::Status>;
         /// Retrieve closest points based on vector similarity and given filtering
         /// conditions
+        ///
+        /// Deprecated: use `QueryBatch` instead.
         async fn search_batch(
             &self,
             request: tonic::Request<super::SearchBatchPoints>,
@@ -7279,6 +7305,8 @@ pub mod points_server {
         >;
         /// Retrieve closest points based on vector similarity and given filtering
         /// conditions, grouped by a given field
+        ///
+        /// Deprecated: use `QueryGroups` instead.
         async fn search_groups(
             &self,
             request: tonic::Request<super::SearchPointGroups>,
@@ -7293,6 +7321,8 @@ pub mod points_server {
         ) -> std::result::Result<tonic::Response<super::ScrollResponse>, tonic::Status>;
         /// Look for the points which are closer to stored positive examples and at
         /// the same time further to negative examples.
+        ///
+        /// Deprecated: use `Query` with a `recommend` query instead.
         async fn recommend(
             &self,
             request: tonic::Request<super::RecommendPoints>,
@@ -7302,6 +7332,8 @@ pub mod points_server {
         >;
         /// Look for the points which are closer to stored positive examples and at
         /// the same time further to negative examples.
+        ///
+        /// Deprecated: use `QueryBatch` with `recommend` queries instead.
         async fn recommend_batch(
             &self,
             request: tonic::Request<super::RecommendBatchPoints>,
@@ -7311,6 +7343,8 @@ pub mod points_server {
         >;
         /// Look for the points which are closer to stored positive examples and at
         /// the same time further to negative examples, grouped by a given field
+        ///
+        /// Deprecated: use `QueryGroups` with a `recommend` query instead.
         async fn recommend_groups(
             &self,
             request: tonic::Request<super::RecommendPointGroups>,
@@ -7337,6 +7371,8 @@ pub mod points_server {
         /// distance to the target. The context part of the score for each pair is
         /// calculated +1 if the point is closer to a positive than to a negative part
         /// of a pair, and -1 otherwise.
+        ///
+        /// Deprecated: use `Query` with a `discover` or `context` query instead.
         async fn discover(
             &self,
             request: tonic::Request<super::DiscoverPoints>,
@@ -7345,6 +7381,8 @@ pub mod points_server {
             tonic::Status,
         >;
         /// Batch request points based on { positive, negative } pairs of examples, and/or a target
+        ///
+        /// Deprecated: use `QueryBatch` with `discover` or `context` queries instead.
         async fn discover_batch(
             &self,
             request: tonic::Request<super::DiscoverBatchPoints>,

--- a/src/qdrant_client/search.rs
+++ b/src/qdrant_client/search.rs
@@ -39,6 +39,9 @@ impl Qdrant {
     /// ```
     ///
     /// Documentation: <https://qdrant.tech/documentation/concepts/search/#search-api>
+    ///
+    /// Deprecated since 1.20.0, use [`query`](Qdrant::query) instead.
+    #[allow(deprecated)]
     pub async fn search_points(
         &self,
         request: impl Into<SearchPoints>,
@@ -79,6 +82,9 @@ impl Qdrant {
     /// ```
     ///
     /// Documentation: <https://qdrant.tech/documentation/concepts/search/#batch-search-api>
+    ///
+    /// Deprecated since 1.20.0, use [`query_batch`](Qdrant::query_batch) instead.
+    #[allow(deprecated)]
     pub async fn search_batch_points(
         &self,
         request: impl Into<SearchBatchPoints>,
@@ -114,6 +120,9 @@ impl Qdrant {
     /// ```
     ///
     /// Documentation: <https://qdrant.tech/documentation/concepts/search/#search-groups>
+    ///
+    /// Deprecated since 1.20.0, use [`query_groups`](Qdrant::query_groups) instead.
+    #[allow(deprecated)]
     pub async fn search_groups(
         &self,
         request: impl Into<SearchPointGroups>,
@@ -155,6 +164,10 @@ impl Qdrant {
     /// ```
     ///
     /// Documentation: <https://qdrant.tech/documentation/concepts/explore/#recommendation-api>
+    ///
+    /// Deprecated since 1.20.0, use [`query`](Qdrant::query) with a
+    /// [`RecommendInput`](crate::qdrant::RecommendInput) query instead.
+    #[allow(deprecated)]
     pub async fn recommend(
         &self,
         request: impl Into<RecommendPoints>,
@@ -204,6 +217,10 @@ impl Qdrant {
     /// ```
     ///
     /// Documentation: <https://qdrant.tech/documentation/concepts/explore/#batch-recommendation-api>
+    ///
+    /// Deprecated since 1.20.0, use [`query_batch`](Qdrant::query_batch) with
+    /// [`RecommendInput`](crate::qdrant::RecommendInput) queries instead.
+    #[allow(deprecated)]
     pub async fn recommend_batch(
         &self,
         request: impl Into<RecommendBatchPoints>,
@@ -244,6 +261,10 @@ impl Qdrant {
     /// ```
     ///
     /// Documentation: <https://qdrant.tech/documentation/concepts/explore/#recommendation-api>
+    ///
+    /// Deprecated since 1.20.0, use [`query_groups`](Qdrant::query_groups) with a
+    /// [`RecommendInput`](crate::qdrant::RecommendInput) query instead.
+    #[allow(deprecated)]
     pub async fn recommend_groups(
         &self,
         request: impl Into<RecommendPointGroups>,
@@ -294,6 +315,11 @@ impl Qdrant {
     /// ```
     ///
     /// Documentation: <https://qdrant.tech/documentation/concepts/explore/#discovery-api>
+    ///
+    /// Deprecated since 1.20.0, use [`query`](Qdrant::query) with a
+    /// [`DiscoverInput`](crate::qdrant::DiscoverInput) or
+    /// [`ContextInput`](crate::qdrant::ContextInput) query instead.
+    #[allow(deprecated)]
     pub async fn discover(
         &self,
         request: impl Into<DiscoverPoints>,
@@ -360,6 +386,11 @@ impl Qdrant {
     /// ```
     ///
     /// Documentation: <https://qdrant.tech/documentation/concepts/explore/#discovery-api>
+    ///
+    /// Deprecated since 1.20.0, use [`query_batch`](Qdrant::query_batch) with
+    /// [`DiscoverInput`](crate::qdrant::DiscoverInput) or
+    /// [`ContextInput`](crate::qdrant::ContextInput) queries instead.
+    #[allow(deprecated)]
     pub async fn discover_batch(
         &self,
         request: &DiscoverBatchPoints,

--- a/tests/snippet_tests/test_update_collection_memory.rs
+++ b/tests/snippet_tests/test_update_collection_memory.rs
@@ -4,7 +4,7 @@ async fn test_update_collection_memory() {
     async fn update_collection_memory() -> Result<(), Box<dyn std::error::Error>> {
         use qdrant_client::qdrant::{
             vectors_config_diff, CollectionParamsDiffBuilder, Memory, PayloadStorageParamsBuilder,
-            StrictModeConfigBuilder, UpdateCollectionBuilder, VectorParamsDiffBuilder,
+            UpdateCollectionBuilder, VectorParamsDiffBuilder,
         };
         use qdrant_client::Qdrant;
 
@@ -21,13 +21,7 @@ async fn test_update_collection_memory() {
                     // Move the original vectors to disk
                     .vectors_config(vectors_config_diff::Config::from(
                         VectorParamsDiffBuilder::default().memory(Memory::Cold),
-                    ))
-                    // Reject updates once the storage filesystem is 90% full
-                    .strict_mode_config(
-                        StrictModeConfigBuilder::default()
-                            .enabled(true)
-                            .max_disk_usage_percent(90),
-                    ),
+                    )),
             )
             .await?;
         Ok(())


### PR DESCRIPTION
Follow-up to #288. Upstream `dev` changed the API again after that sync — re-ran `./tools/sync_proto.sh` and adjusted the hand-written surface.

### Protobuf changes picked up

**`StrictModeConfig`** (`collections.proto`)
- `max_disk_usage_percent` (field 22) is **removed** and reserved — superseded by the global quota config.
- `max_resident_memory_percent` (field 21) is now `[deprecated = true]` for the same reason (memory is node-wide), removal planned for 1.21.

**Points service** (`points_service.proto`)
- `Search`, `SearchBatch`, `SearchGroups`, `Recommend`, `RecommendBatch`, `RecommendGroups`, `Discover` and `DiscoverBatch` are marked `option deprecated = true` in favour of the Query API, so the generated tonic client methods now carry `#[deprecated]`.

### Client changes

- `StrictModeConfigBuilder::max_disk_usage_percent` is dropped. The field never shipped — latest tag is `v1.18.0` and it was only added in the unreleased #288 — so no published version breaks.
- `StrictModeConfigBuilder::max_resident_memory_percent` keeps working and gains a doc note about the deprecation rather than a `#[deprecated]` attribute, matching the convention established in #288 (an attribute would be a hard error for downstream crates building with `-D warnings`). `build_inner` gets `#[allow(deprecated)]`, same as the other builders touching deprecated fields.
- The eight `Qdrant::search_points` / `recommend` / `discover` wrappers get `#[allow(deprecated)]` around the now-deprecated tonic calls, plus doc notes pointing at their Query API replacements. They stay callable warning-free, so a 1.18 -> 1.20 bump remains source-compatible.
- `tests/snippet_tests/test_update_collection_memory.rs` no longer sets the removed field.

### Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `tests/integration-tests.sh` against `qdrant/qdrant:dev` — 30 + 1 + 1 + 79 + 111 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)